### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "font-awesome": "^4.7.0",
     "jquery": "^3.1.1",
     "nw-builder": "^3.1.3",
-    "ripple-lib": "^0.12.0",
+    "ripple-lib": "^0.17.0",
     "sjcl": "^1.0.6",
     "stellar-sdk": "^0.6.2",
     "underscore": "^1.8.3"


### PR DESCRIPTION
Can't build with "ripple-lib": "^0.12.0" anymore (0.12.8), changed to ^0.17.0