### PR TITLE
Updates ripple-lib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "font-awesome": "^4.7.0",
     "jquery": "^3.1.1",
     "nw-builder": "^3.1.3",
-    "ripple-lib": "0.12.5-rc2",
+    "ripple-lib": "^0.17.9",
     "sjcl": "^1.0.6",
     "stellar-sdk": "^0.6.2",
     "underscore": "^1.8.3"

--- a/src/app.html
+++ b/src/app.html
@@ -20,7 +20,7 @@
 	<script src="../node_modules/chart.js/dist/Chart.min.js"></script>
 	<script src="../node_modules/angular-chart.js/dist/angular-chart.min.js"></script>
 	<script src="../node_modules/underscore/underscore-min.js"></script>
-	<script src="../node_modules/ripple-lib/build/ripple-0.12.5-rc2-min.js"></script>
+	<script src="../node_modules/ripple-lib/build/ripple-latest-min.js"></script>
 	<script src="../node_modules/stellar-sdk/dist/stellar-sdk.min.js"></script>
 	
 	<script src="js/lang/translate_cn.js"></script>


### PR DESCRIPTION
After the #138 merge that rolled back ripple-lib, I was unable to install and build all the dependencies.

`ripple-lib@0.12.5-rc2` were having problems with 2 dependencies:
`bufferutil` and `utf-8-validate`. Upgrading it makes it work.

```
├─┬ ripple-lib@0.12.5-rc2
│ ├── async@0.9.2
│ ├── bignumber.js@2.4.0
│ ├── extend@1.2.1
│ ├── lodash@3.10.1
│ ├── lru-cache@2.5.2
│ ├── ripple-wallet-generator@1.0.3
│ └─┬ ws@0.7.2
│   ├── UNMET OPTIONAL DEPENDENCY bufferutil@1.1.x
│   ├── options@0.0.6
│   ├── ultron@1.0.2
│   └── UNMET OPTIONAL DEPENDENCY utf-8-validate@1.1.x
```