### PR TITLE
Generalize to network agnostic stellar (technology) wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /cache
 /build
+/src/node_modules

--- a/src/directive/tx-batch.html
+++ b/src/directive/tx-batch.html
@@ -16,12 +16,12 @@
 			<div ng-switch-when="createAccount" class="batchrow">
 				<div class="cell">{{op.type}}</div>
 				<div class="cell">{{op.destination}}</div>
-				<div class="txamount cell">{{op.startingBalance}} {{op.asset.code}}</div>
+				<div class="txamount cell">{{op.startingBalance}} {{item.nativeCode}}</div>
 			</div>
 			<div ng-switch-when="pathPayment" class="batchrow">
 				<div class="cell">{{op.type}}</div>
 				<div class="cell">{{op.destination}}</div>
-				<div class="txamount cell">{{op.destAmount}} {{op.destAsset.code}}</div>
+				<div class="txamount cell">{{op.destAmount}} {{op.destAsset.issuer ? op.destAsset.code : item.nativeCode}}</div>
 			</div>
 			<div ng-switch-when="changeTrust" class="batchrow">
 				<div class="cell">{{op.type}}</div>
@@ -30,9 +30,9 @@
 			</div>
 			<div ng-switch-when="manageOffer" class="batchrow">
 				<div class="cell">{{op.type}}</div>
-				<div class="cell">{{op.amount}} {{op.selling.code}} 
+				<div class="cell">{{op.amount}} {{op.selling.issuer ? op.selling.code : item.nativeCode}}
 					<span class="glyphicon glyphicon-arrow-right"></span>
-					{{op.buying.code}}
+					{{op.buying.issuer ? op.buying.code : item.nativeCode}}
 					{{'price' | translate}}: {{op.price}}
 				</div>
 			</div>

--- a/src/directive/tx-offer.html
+++ b/src/directive/tx-offer.html
@@ -5,14 +5,14 @@
 	</div>
 	<div class="feed-item-comment">
 		<span ng-if="item.source_account !== address" class="timestamp nowrap">{{'source_account' | translate}}: {{item.source_account}}</span>
-		<span>{{item.tx.operations[0].selling.code}}/{{item.tx.operations[0].buying.code}}</span>
+		<span>{{item.tx.operations[0].selling.issuer ? item.tx.operations[0].selling.code : item.nativeCode}}/{{item.tx.operations[0].buying.issuer ? item.tx.operations[0].buying.code : item.nativeCode}}</span>
 	</div>
 
 	<div class="payment">
 		<div class="txamount">
-		{{item.tx.operations[0].amount}} {{item.tx.operations[0].selling.code}} 
+		{{item.tx.operations[0].amount}} {{item.tx.operations[0].selling.issuer ? item.tx.operations[0].selling.code : item.nativeCode}} 
 		<span class="glyphicon glyphicon-arrow-right"></span>
-		{{item.tx.operations[0].buying.code}}
+		{{item.tx.operations[0].buying.issuer ? item.tx.operations[0].buying.code : item.nativeCode}}
 		
 		{{'price' | translate}}: {{item.tx.operations[0].price}}</div>
 		<div class="timestamp">{{item.date | date:'yyyy-MM-dd HH:mm:ss'}}</div>

--- a/src/directive/tx-pathPayment.html
+++ b/src/directive/tx-pathPayment.html
@@ -17,12 +17,12 @@
 	</div>
 
 	<div class="payment">
-		<div class="txamount">{{item.tx.operations[0].amount}} {{item.tx.operations[0].asset.code}}</div>
+		<div class="txamount">{{item.tx.operations[0].amount}} {{item.tx.operations[0].asset.issuer ? item.tx.operations[0].asset.code : item.nativeCode}}</div>
 		
 		<div class="txamount">
-		{{item.tx.operations[0].sendMax}} {{item.tx.operations[0].sendAsset.code}} 
+		{{item.tx.operations[0].sendMax}} {{item.tx.operations[0].sendAsset.issuer ? item.tx.operations[0].sendAsset.code : item.nativeCode}} 
 		<span class="glyphicon glyphicon-arrow-right"></span>
-		{{item.tx.operations[0].destAmount}} {{item.tx.operations[0].destAsset.code}}
+		{{item.tx.operations[0].destAmount}} {{item.tx.operations[0].destAsset.issuer ? item.tx.operations[0].destAsset.code : item.nativeCode}}
 		
 		<div class="timestamp">{{item.date | date:'yyyy-MM-dd HH:mm:ss'}}</div>
 		

--- a/src/directive/tx-payment.html
+++ b/src/directive/tx-payment.html
@@ -12,7 +12,7 @@
 	</div>
 
 	<div class="payment">
-		<div class="txamount">{{item.tx.operations[0].amount}} {{item.tx.operations[0].asset.code}}</div>
+		<div class="txamount">{{item.tx.operations[0].amount}} {{item.tx.operations[0].asset.issuer ? item.tx.operations[0].asset.code : item.nativeCode}}</div>
 		<div class="timestamp">{{item.date | date:'yyyy-MM-dd HH:mm:ss'}}</div>
 	</div>
 </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -180,7 +180,7 @@ myApp.run(['$rootScope', '$window', '$location', '$translate', 'AuthenticationFa
     $rootScope.reserve = 0;
     $rootScope.lines = {}; // lines.CNY.xxx = {code: 'CNY', issuer: 'xxx', balance: 200, limit: 1000}
     $rootScope.getBalance = function(code, issuer) {
-      if (code == $scope.currentNetwork.coin.code) {
+      if (code == $rootScope.currentNetwork.coin.code) {
         return $rootScope.balance;
       } else {
         return $rootScope.lines[code] && $rootScope.lines[code][issuer] ? $rootScope.lines[code][issuer].balance : 0;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,12 +2,14 @@
 /* exported myApp */
 var myApp = angular.module('myApp', ['ngRoute', 'pascalprecht.translate', 'chart.js', 'monospaced.qrcode']);
 
-myApp.config(function($routeProvider, $httpProvider, $translateProvider) {
+myApp.config(function($routeProvider, $httpProvider, $translateProvider, $compileProvider) {
   $translateProvider.translations('cn', translate_cn);
   $translateProvider.translations('en', translate_en);
   $translateProvider.translations('fr', translate_fr);
   $translateProvider.preferredLanguage('cn');
   $translateProvider.useSanitizeValueStrategy('escape');
+
+  $compileProvider.imgSrcSanitizationWhitelist(/^\s*(local|http|https|app|tel|ftp|file|blob|content|ms-appx|x-wmapp0|cdvfile|chrome-extension):|data:image\//);
 
   $httpProvider.interceptors.push('TokenInterceptor');
 
@@ -178,7 +180,7 @@ myApp.run(['$rootScope', '$window', '$location', '$translate', 'AuthenticationFa
     $rootScope.reserve = 0;
     $rootScope.lines = {}; // lines.CNY.xxx = {code: 'CNY', issuer: 'xxx', balance: 200, limit: 1000}
     $rootScope.getBalance = function(code, issuer) {
-      if (code == 'XLM') {
+      if (code == $scope.currentNetwork.coin.code) {
         return $rootScope.balance;
       } else {
         return $rootScope.lines[code] && $rootScope.lines[code][issuer] ? $rootScope.lines[code][issuer].balance : 0;
@@ -252,15 +254,7 @@ myApp.run(['$rootScope', '$window', '$location', '$translate', 'AuthenticationFa
     $rootScope.isValidAddress = function(address) {
       return StellarApi.isValidAddress(address);
     }
-    $rootScope.isPublicNetwork = function() {
-      return SettingFactory.getNetworkType() == 'public';
-    }
-    $rootScope.isTestNetwork = function() {
-      return SettingFactory.getNetworkType() == 'test';
-    }
-    $rootScope.isOtherNetwork = function() {
-      return SettingFactory.getNetworkType() == 'other';
-    }
+    $rootScope.currentNetwork = SettingFactory.getCurrentNetwork();
 
     $rootScope.isLangCN = function() {
       return SettingFactory.getLang() == 'cn';
@@ -268,17 +262,11 @@ myApp.run(['$rootScope', '$window', '$location', '$translate', 'AuthenticationFa
 
     $translate.use(SettingFactory.getLang());
     try {
-      if ('test' == SettingFactory.getNetworkType()) {
-        StellarApi.setServer(SettingFactory.getTestUrl(), 'test');
-      } else if ('other' == SettingFactory.getNetworkType()) {
-        StellarApi.setServer(SettingFactory.getOtherUrl(), 'other', SettingFactory.getNetPassphrase());
-      } else {
-        StellarApi.setServer(SettingFactory.getStellarUrl(), SettingFactory.getNetworkType());
-      }
+      StellarApi.setServer(SettingFactory.getStellarUrl(), SettingFactory.getNetPassphrase(), SettingFactory.getAllowHttp());
     } catch(e) {
-      console.error("Cannot set server", SettingFactory.getStellarUrl(), e);
-      console.warn("Change network back to public.");
-      SettingFactory.setNetworkType('public');
+      console.error("Cannot set server", SettingFactory.getStellarUrl(), SettingFactory.getNetworkType(), e);
+      console.warn("Change network back to xlm.");
+      SettingFactory.setNetworkType('xlm');
       StellarApi.setServer(null);
     }
 

--- a/src/js/controller/balance.js
+++ b/src/js/controller/balance.js
@@ -39,7 +39,7 @@ myApp.controller("BalanceCtrl", [ '$scope', '$rootScope', '$http', 'StellarApi',
     $scope.price = {};
     $scope.getPrice = function(code, issuer, callback) {
       var base = {code: code, issuer: issuer};
-      var counter = {code: 'XLM', issuer: ''};
+      var counter = {code: $rootScope.currentNetwork.coin.code, issuer: ''};
       StellarApi.queryBook(base, counter, function(err, data) {
         if (err) {
           console.error('Price ' + base + '.' + issuer, err);

--- a/src/js/controller/convert.js
+++ b/src/js/controller/convert.js
@@ -6,7 +6,7 @@ myApp.controller("ConvertCtrl", ['$scope', '$rootScope', 'StellarApi', 'SettingF
     $scope.dst_amount = 0;
     $scope.dst_currency = '';
     $scope.init = function(){
-      $scope.send.push({code: 'XLM', issuer: ''});
+      $scope.send.push({code: $rootScope.currentNetwork.coin.code, issuer: ''});
       for (var code in $rootScope.lines) {
         for(var issuer in $rootScope.lines[code]) {
           $scope.send.push({code: code, issuer: issuer});
@@ -21,7 +21,7 @@ myApp.controller("ConvertCtrl", ['$scope', '$rootScope', 'StellarApi', 'SettingF
       $scope.asset = $scope.paths[code + '.' + issuer];
     };
     $scope.isLine = function(code, issuer) {
-      if (code == 'XLM') {
+      if (code == $rootScope.currentNetwork.coin.code) {
         return code == $scope.asset.src_code;
       } else {
         return code == $scope.asset.src_code && issuer == $scope.asset.src_issuer;
@@ -51,10 +51,10 @@ myApp.controller("ConvertCtrl", ['$scope', '$rootScope', 'StellarApi', 'SettingF
           data.records.forEach(function(item){
             var alt = {
               origin: item,
-              dst_code   : item.destination_asset_type == 'native' ? 'XLM' : item.destination_asset_code,
+              dst_code   : item.destination_asset_type == 'native' ? $rootScope.currentNetwork.coin.code : item.destination_asset_code,
               dst_issuer : item.destination_asset_type == 'native' ? '' : item.destination_asset_issuer,
               src_amount : parseFloat(item.source_amount),
-              src_code   : item.source_asset_type == 'native' ? 'XLM' : item.source_asset_code,
+              src_code   : item.source_asset_type == 'native' ? $rootScope.currentNetwork.coin.code : item.source_asset_code,
               src_issuer : item.source_asset_type == 'native' ? '' : item.source_asset_issuer,
             };
             alt.precise = alt.src_code == 'BTC' ? 6 : 3;
@@ -68,7 +68,7 @@ myApp.controller("ConvertCtrl", ['$scope', '$rootScope', 'StellarApi', 'SettingF
             if (alt.src_amount <= 0) {
               isValid = false;
             } else {
-              if (alt.src_code == 'XLM') {
+              if (alt.src_code == $rootScope.currentNetwork.coin.code) {
                 if ($rootScope.balance - alt.src_amount < 0) {
                   isValid = false;
                 }

--- a/src/js/controller/send.js
+++ b/src/js/controller/send.js
@@ -51,7 +51,14 @@ myApp.controller("SendCtrl", ['$scope', '$rootScope', '$routeParams', 'StellarAp
       }
       return !$scope.send_error.memo;
     };
-    $scope.pick = function(code, issuer) {
+    $scope.pickCoin = function() {
+      $scope.asset.code = $rootScope.currentNetwork.coin.code;
+      $scope.asset.issuer = undefined;
+      $scope.asset.name = $rootScope.currentNetwork.coin.name;
+      $scope.asset.logo = $rootScope.currentNetwork.coin.logo;
+      $scope.asset.website = $rootScope.currentNetwork.website;
+    };
+    $scope.pickToken = function(code, issuer) {
       $scope.asset.code = code;
       $scope.asset.issuer = issuer;
       var gateway = $rootScope.gateways.getSourceById(issuer);
@@ -60,7 +67,7 @@ myApp.controller("SendCtrl", ['$scope', '$rootScope', '$routeParams', 'StellarAp
       $scope.asset.website = gateway.website;
     };
     $scope.isLine = function(code, issuer) {
-      if (code == 'XLM') {
+      if(code === $rootScope.currentNetwork.coin.code && !issuer) {
         return code == $scope.asset.code;
       } else {
         return code == $scope.asset.code && issuer == $scope.asset.issuer;
@@ -320,16 +327,15 @@ myApp.controller("SendCtrl", ['$scope', '$rootScope', '$routeParams', 'StellarAp
         if (err) {
           if (err.message == "NotFoundError") {
             $scope.real_not_fund = true;
-            var gateway = $rootScope.gateways.getSourceById('');
             $scope.send.unshift({
-              code   : 'XLM',
+              code   : $rootScope.currentNetwork.coin.code,
               issuer : '',
-              name   : gateway.name,
-              logo   : gateway.logo
+              name   : $rootScope.currentNetwork.coin.name,
+              logo   : $rootScope.currentNetwork.coin.logo
             });
 
-            if ($scope.asset.code !== 'XLM') {
-              $scope.pick('XLM', '');
+            if ($scope.asset.code !== $rootScope.currentNetwork.coin.code) {
+              $scope.pickCoin();
             }
           } else {
             console.error('resolveAccountInfo', err);
@@ -339,20 +345,22 @@ myApp.controller("SendCtrl", ['$scope', '$rootScope', '$routeParams', 'StellarAp
           var code, issuer, name, logo;
           data.balances.forEach(function(line){
             if (line.asset_type == 'native') {
-              accept.push('XLM');
-              code = 'XLM';
+              accept.push($rootScope.currentNetwork.coin.code);
+              code = $rootScope.currentNetwork.coin.code;
               issuer = '';
+              name = $rootScope.currentNetwork.coin.name;
+              logo = $rootScope.currentNetwork.coin.logo;
             } else {
               if (accept.indexOf(line.asset_code) < 0) {
                 accept.push(line.asset_code);
               }
               code = line.asset_code;
               issuer = line.asset_issuer;
+              var gateway = $rootScope.gateways.getSourceById(issuer);
+              name = gateway.name;
+              logo = gateway.logo;
             }
 
-            var gateway = $rootScope.gateways.getSourceById(issuer);
-            name = gateway.name;
-            logo = gateway.logo;
             $scope.send.unshift({
               code   : code,
               issuer : issuer,

--- a/src/js/controller/settings.js
+++ b/src/js/controller/settings.js
@@ -27,7 +27,7 @@ myApp.controller("SettingsCtrl", [ '$scope', '$rootScope', '$location', 'Setting
     $scope.fed_bitcoin = SettingFactory.getFedBitcoin();
     $scope.set = function(network) {
       $scope.network_type = network;
-      $scope.network_horizon = SettingFactory.DEFAULT_HORIZONS[network];
+      $scope.network_horizon = SettingFactory.NETWORKS[network].defaultHorizon;
       if(network === 'other') {
         $scope.network_passphrase = undefined;
         $scope.network_coin = undefined;

--- a/src/js/controller/settings.js
+++ b/src/js/controller/settings.js
@@ -27,7 +27,7 @@ myApp.controller("SettingsCtrl", [ '$scope', '$rootScope', '$location', 'Setting
     $scope.fed_bitcoin = SettingFactory.getFedBitcoin();
     $scope.set = function(network) {
       $scope.network_type = network;
-      $scope.network_horizon = SettingFactory.NETWORKS[network].defaultHorizon;
+      $scope.network_horizon = SettingFactory.NETWORKS[network].knownHorizons[0];
       if(network === 'other') {
         $scope.network_passphrase = undefined;
         $scope.network_coin = undefined;

--- a/src/js/controller/settings.js
+++ b/src/js/controller/settings.js
@@ -55,6 +55,7 @@ myApp.controller("SettingsCtrl", [ '$scope', '$rootScope', '$location', 'Setting
             StellarApi.logout();
             $rootScope.reset();
             $rootScope.$broadcast('$blobUpdate');
+            location.reload();
 
           } catch (e) {
             console.error(e);

--- a/src/js/controller/settings.js
+++ b/src/js/controller/settings.js
@@ -11,56 +11,51 @@ myApp.controller("SettingsCtrl", [ '$scope', '$rootScope', '$location', 'Setting
     }
 
     $scope.proxy = SettingFactory.getProxy();
+
+    $scope.active_network = SettingFactory.getNetworkType();
+    $scope.active_horizon = SettingFactory.getStellarUrl();
+    $scope.active_passphrase = SettingFactory.getNetPassphrase();
+    $scope.active_coin = SettingFactory.getCoin();
     $scope.network_type = SettingFactory.getNetworkType();
-    $scope.url = SettingFactory.getStellarUrl();
-    $scope.test_url = SettingFactory.getTestUrl();
-    $scope.other_url = SettingFactory.getOtherUrl();
-    $scope.passphrase = SettingFactory.getNetPassphrase();
+    $scope.network_horizon = SettingFactory.getStellarUrl();
+    $scope.network_passphrase = SettingFactory.getNetPassphrase();
+    $scope.network_coin = SettingFactory.getCoin();
+    $scope.all_networks = SettingFactory.NETWORKS;
 
     $scope.fed_network = SettingFactory.getFedNetwork();
     $scope.fed_ripple  = SettingFactory.getFedRipple();
     $scope.fed_bitcoin = SettingFactory.getFedBitcoin();
+    $scope.set = function(network) {
+      $scope.network_type = network;
+      $scope.network_horizon = SettingFactory.DEFAULT_HORIZONS[network];
+      if(network === 'other') {
+        $scope.network_passphrase = undefined;
+        $scope.network_coin = undefined;
+      }
+    }
     $scope.save = function(mode) {
       $scope.network_error = "";
       if (mode == 'network') {
-        SettingFactory.setProxy($scope.proxy);
-        var server_change = false;
-        if (SettingFactory.getNetworkType() != $scope.network_type) {
-          SettingFactory.setNetworkType($scope.network_type);
-          server_change = true;
-        }
-        if (SettingFactory.getTestUrl() != $scope.test_url) {
-          SettingFactory.setTestUrl($scope.test_url);
-          server_change = true;
-        }
-        if (SettingFactory.getStellarUrl() != $scope.url) {
-          SettingFactory.setStellarUrl($scope.url);
-          server_change = true;
-        }
-        if (SettingFactory.getOtherUrl() != $scope.other_url) {
-          SettingFactory.setOtherUrl($scope.other_url);
-          server_change = true;
-        }
-        if (SettingFactory.getNetPassphrase() != $scope.passphrase) {
-          SettingFactory.setNetPassphrase($scope.passphrase);
-          server_change = true;
-        }
-
-        if (server_change) {
+        if ($scope.active_network !== $scope.network_type ||
+            $scope.active_horizon !== $scope.network_passphrase ||
+            $scope.active_passphrase !== $scope.network_horizon ||
+            $scope.active_coin !== $scope.network_coin) {
           try {
-            var url = "";
-            if ($scope.network_type == 'test') {
-              url = $scope.test_url;
-            } else if ($scope.network_type == 'other') {
-              url = $scope.other_url;
-            } else {
-              $scope.url;
-            }
+            SettingFactory.setNetworkType($scope.network_type);
+            SettingFactory.setStellarUrl($scope.network_horizon);
+            SettingFactory.setNetPassphrase($scope.network_passphrase);
+            SettingFactory.setCoin($scope.network_coin);
 
-            StellarApi.setServer(url, $scope.network_type, $scope.passphrase);
+            $scope.active_network = SettingFactory.getNetworkType()
+            $scope.active_horizon = SettingFactory.getStellarUrl()
+            $scope.active_passphrase = SettingFactory.getNetPassphrase()
+            $scope.active_coin = SettingFactory.getCoin()
+
+            StellarApi.setServer($scope.active_horizon, $scope.active_passphrase, SettingFactory.getAllowHttp());
             StellarApi.logout();
             $rootScope.reset();
             $rootScope.$broadcast('$blobUpdate');
+
           } catch (e) {
             console.error(e);
             $scope.network_error = e.message;
@@ -72,6 +67,10 @@ myApp.controller("SettingsCtrl", [ '$scope', '$rootScope', '$location', 'Setting
         SettingFactory.setFedNetwork($scope.fed_network);
         SettingFactory.setFedRipple($scope.fed_ripple);
         SettingFactory.setFedBitcoin($scope.fed_bitcoin);
+      }
+
+      if (mode == 'proxy') {
+        SettingFactory.setProxy($scope.proxy);
       }
     };
 

--- a/src/js/controller/trade.js
+++ b/src/js/controller/trade.js
@@ -14,10 +14,10 @@ myApp.controller("TradeCtrl", [ '$scope', '$rootScope', 'StellarApi', 'StellarOr
         this.bid = {};
         for (var i=0; i<data.length; i++) {
           var offer = data[i];
-          var buy_code = offer.buying.asset_type == 'native' ? 'XLM' : offer.buying.asset_code;
-          var buy_issuer = buy_code == 'XLM' ? '' : offer.buying.asset_issuer;
-          var sell_code = offer.selling.asset_type == 'native' ? 'XLM' : offer.selling.asset_code;
-          var sell_issuer = sell_code == 'XLM' ? '' : offer.selling.asset_issuer;
+          var buy_code = offer.buying.asset_type == 'native' ? $rootScope.currentNetwork.coin.code : offer.buying.asset_code;
+          var buy_issuer = offer.buying.asset_type == 'native' ? '' : offer.buying.asset_issuer;
+          var sell_code = offer.selling.asset_type == 'native' ? $rootScope.currentNetwork.coin.code : offer.selling.asset_code;
+          var sell_issuer = offer.selling.asset_type == 'native' ? '' : offer.selling.asset_issuer;
 
           this.all[offer.id] = {
             id : offer.id,
@@ -242,7 +242,6 @@ myApp.controller("TradeCtrl", [ '$scope', '$rootScope', 'StellarApi', 'StellarOr
       }
     }
 
-    //option {type:'buy', currency:'XLM', issuer: '', base: 'CNY', base_issuer: 'GXXX', amount: 100, price: 0.01}
     $scope.offer = function(type) {
       $scope[type + 'ing'] = true;
       $scope[type + '_ok'] = false;
@@ -351,7 +350,7 @@ myApp.controller("TradeCtrl", [ '$scope', '$rootScope', 'StellarApi', 'StellarOr
     }
 
     function sameAsset(code, issuer, code2, issuer2) {
-      if (code == 'XLM') {
+      if (code == $rootScope.currentNetwork.coin.code) {
         return code == code2;
       } else {
         return code == code2 && issuer == issuer2;
@@ -359,6 +358,11 @@ myApp.controller("TradeCtrl", [ '$scope', '$rootScope', 'StellarApi', 'StellarOr
     }
 
     function getAsset(code, issuer) {
-      return code == 'XLM' ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
+      if (typeof code == 'object') {
+        issuer = code.issuer;
+        code = code.code;
+      }
+      return code == $rootScope.currentNetwork.coin.code ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
     }
+
   } ]);

--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -69,7 +69,7 @@ myApp.controller("HomeCtrl", ['$scope', '$rootScope', 'RemoteFactory',
 
       $scope.pie.total = 0;
       $rootScope.stellar_ticker.assets.forEach(function(asset){
-        if (asset.code == 'XLM') {
+        if (asset.code == $rootScope.currentNetwork.coin.code) {
           //$scope.pie.total = asset.volume24h_XLM;
         } else {
           if (asset.volume24h_XLM) {

--- a/src/js/factory.js
+++ b/src/js/factory.js
@@ -126,7 +126,7 @@ myApp.factory('SettingFactory', function($window) {
         return JSON.parse($window.localStorage['tradepair']);
       } else {
         return {
-          base_code   : 'XLM',
+          base_code   : this.getCurrentNetwork().coin.code,
           base_issuer : '',
           counter_code   : 'CNY',
           counter_issuer : 'GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX'

--- a/src/js/factory.js
+++ b/src/js/factory.js
@@ -10,7 +10,8 @@ myApp.factory('SettingFactory', function($window) {
         networkPassphrase: StellarSdk.Networks.PUBLIC,
         defaultHorizon: "https://horizon.stellar.org",
         coin: {
-          name: "Stellar Network",
+          name: "lumen",
+          atom: "stroop",
           code: "XLM",
           logo: "img/rocket.png"
         },
@@ -23,7 +24,8 @@ myApp.factory('SettingFactory', function($window) {
         networkPassphrase: StellarSdk.Networks.TESTNET,
         defaultHorizon: "https://horizon-testnet.stellar.org",
         coin: {
-          name: "Stellar Network",
+          name: "lumen",
+          atom: "stroop",
           code: "XLM",
           logo: "img/rocket.png"
         },
@@ -37,6 +39,7 @@ myApp.factory('SettingFactory', function($window) {
         defaultHorizon: undefined,
         coin: {
           name: undefined,
+          atom: undefined,
           code: undefined,
           logo: undefined
         },

--- a/src/js/factory.js
+++ b/src/js/factory.js
@@ -2,13 +2,19 @@
 
 myApp.factory('SettingFactory', function($window) {
   return {
-    // To add new preset, add unique prop to NETWORKS, DEFAULT_HORIZONS and COINS, new row at settings.html and translation.
+    // To add new preset network, add new entry here and in `translationKey` to all translations.
+    // P.S. Undefined entries will be asked for in user interface.
     NETWORKS: {
       xlm: {
         name: "Stellar Public Network",
+        translationKey: 'public_url',
         networkType: 'xlm',
         networkPassphrase: StellarSdk.Networks.PUBLIC,
-        defaultHorizon: "https://horizon.stellar.org",
+        knownHorizons: [
+          'https://horizon.stellar.org',  // First one is default.
+          'https://stellar-api.wancloud.io',
+          'https://api.chinastellar.com',
+        ],
         coin: {
           name: "lumen",
           atom: "stroop",
@@ -20,9 +26,12 @@ myApp.factory('SettingFactory', function($window) {
       },
       xlmTest: {
         name: "Stellar Test Network",
+        translationKey: 'test_url',
         networkType: 'xlmTest',
         networkPassphrase: StellarSdk.Networks.TESTNET,
-        defaultHorizon: "https://horizon-testnet.stellar.org",
+        knownHorizons: [
+          'https://horizon-testnet.stellar.org',
+        ],
         coin: {
           name: "lumen",
           atom: "stroop",
@@ -34,14 +43,16 @@ myApp.factory('SettingFactory', function($window) {
       },
       other: {
         name: "User defined",
+        translationKey: 'other_url',
         networkType: 'other',
         networkPassphrase: undefined,
-        defaultHorizon: undefined,
+        knownHorizons: [
+        ],
         coin: {
-          name: undefined,
-          atom: undefined,
+          name: "lumen",  // TODO: ask in settings
+          atom: "stroop",  // TODO: ask in settings
           code: undefined,
-          logo: undefined
+          logo: "img/rocket.png",  // TODO: ask in settings
         },
         allowHTTP: true,
         tabs: ["history", "trade", "balance", "send", "trust"]
@@ -81,7 +92,7 @@ myApp.factory('SettingFactory', function($window) {
       return this.NETWORKS[this.getNetworkType()];
     },
     setStellarUrl : function(url) {
-      return $window.localStorage[`network_horizon/${this.getNetworkType()}`] = url || this.NETWORKS[this.getNetworkType()].defaultHorizon;
+      return $window.localStorage[`network_horizon/${this.getNetworkType()}`] = url || this.NETWORKS[this.getNetworkType()].knownHorizons[0];
     },
     getStellarUrl : function() {
       return $window.localStorage[`network_horizon/${this.getNetworkType()}`] || this.setStellarUrl();

--- a/src/js/factory.js
+++ b/src/js/factory.js
@@ -2,8 +2,50 @@
 
 myApp.factory('SettingFactory', function($window) {
   return {
+    // To add new preset, add unique prop to NETWORKS, DEFAULT_HORIZONS and COINS, new row at settings.html and translation.
+    NETWORKS: {
+      xlm: {
+        name: "Stellar Public Network",
+        networkType: 'xlm',
+        networkPassphrase: StellarSdk.Networks.PUBLIC,
+        defaultHorizon: "https://horizon.stellar.org",
+        coin: {
+          name: "Stellar Network",
+          code: "XLM",
+          logo: "stellar.png"
+        },
+        allowHTTP: false,
+        tabs: ["history", "trade", "balance", "send", "trust", "service", "ico"]
+      },
+      xlmTest: {
+        name: "Stellar Test Network",
+        networkType: 'xlmTest',
+        networkPassphrase: StellarSdk.Networks.TESTNET,
+        defaultHorizon: "https://horizon-testnet.stellar.org",
+        coin: {
+          name: "Stellar Network",
+          code: "XLM",
+          logo: "stellar.png"
+        },
+        allowHTTP: true,
+        tabs: ["history", "trade", "balance", "send", "trust"]
+      },
+      other: {
+        name: "User defined",
+        networkType: 'other',
+        networkPassphrase: undefined,
+        defaultHorizon: undefined,
+        coin: {
+          name: undefined,
+          code: undefined,
+          logo: undefined
+        },
+        allowHTTP: true,
+        tabs: ["history", "trade", "balance", "send", "trust"]
+      }
+    },
     setLang : function(lang) {
-      $window.localStorage['lang'] = lang;
+      return $window.localStorage['lang'] = lang;
     },
     getLang : function() {
       if ($window.localStorage['lang']) {
@@ -18,51 +60,44 @@ myApp.factory('SettingFactory', function($window) {
         }
       }
     },
+
     setProxy : function(proxy) {
-      if ("undefined" == proxy) {
-        proxy = "";
-      }
-      $window.localStorage['proxy'] = proxy;
+      return $window.localStorage[`proxy`] = "undefined" === proxy ? '' : proxy;
     },
     getProxy : function() {
-      return $window.localStorage['proxy'] || "";
+      return $window.localStorage[`proxy`] || "";
     },
-    setNetworkType : function(type) {
-      if (type == 'test' || type == 'other') {
-        $window.localStorage['network_type'] = type;
-      } else {
-        $window.localStorage['network_type'] = 'public';
-      }
+
+    setNetworkType : function(network) {
+      return $window.localStorage[`network_type`] = network in this.NETWORKS ? network : 'xlm';
     },
     getNetworkType : function() {
-      return $window.localStorage['network_type'] || "public";
+      return $window.localStorage[`network_type`] || this.setNetworkType();
+    },
+    getCurrentNetwork : function() {
+      return this.NETWORKS[this.getNetworkType()];
     },
     setStellarUrl : function(url) {
-      $window.localStorage['stellar_url'] = url;
+      return $window.localStorage[`network_horizon/${this.getNetworkType()}`] = this.NETWORKS[this.getNetworkType()].defaultHorizon;
     },
-    getStellarUrl : function(url) {
-      if ($window.localStorage['stellar_url']) {
-        return $window.localStorage['stellar_url'];
-      }
-      return this.getLang() == 'cn' ? "https://horizon.stellar.org" : 'https://horizon.stellar.org';
-    },
-    setTestUrl : function(url) {
-      $window.localStorage['test_url'] = url;
-    },
-    getTestUrl : function(url) {
-      return $window.localStorage['test_url'] || "https://horizon-testnet.stellar.org";
-    },
-    setOtherUrl : function(url) {
-      $window.localStorage['other_url'] = url;
-    },
-    getOtherUrl : function(url) {
-      return $window.localStorage['other_url'];
+    getStellarUrl : function() {
+      return $window.localStorage[`network_horizon/${this.getNetworkType()}`] || this.setStellarUrl();
     },
     setNetPassphrase : function(val) {
-      $window.localStorage['net_passphase'] = val;
+      //return this.getNetworkType() === 'other' ? $window.localStorage[`network_passphase/${this.getNetworkType()}`] = val : this.NETWORKS[this.getNetworkType()];
+      return $window.localStorage
     },
-    getNetPassphrase : function(url) {
-      return $window.localStorage['net_passphase'];
+    getNetPassphrase : function() {
+      return this.getNetworkType() === 'other' ? $window.localStorage[`network_passphrase/${this.getNetworkType()}`] : this.NETWORKS[this.getNetworkType()].networkPassphrase;
+    },
+    setCoin : function(val) {
+      return this.getNetworkType() === 'other' ? $window.localStorage[`network_coin/${this.getNetworkType()}`] = val : this.NETWORKS[this.getNetworkType()].coin.code;
+    },
+    getCoin : function() {
+      return this.getNetworkType() === 'other' ? $window.localStorage[`network_coin/${this.getNetworkType()}`] : this.NETWORKS[this.getNetworkType()].coin.code;
+    },
+    getAllowHttp : function() {
+      return this.NETWORKS[this.getNetworkType()].allowHTTP;
     },
 
     setFedNetwork : function(domain) {

--- a/src/js/factory.js
+++ b/src/js/factory.js
@@ -12,7 +12,7 @@ myApp.factory('SettingFactory', function($window) {
         coin: {
           name: "Stellar Network",
           code: "XLM",
-          logo: "stellar.png"
+          logo: "img/rocket.png"
         },
         allowHTTP: false,
         tabs: ["history", "trade", "balance", "send", "trust", "service", "ico"]
@@ -25,7 +25,7 @@ myApp.factory('SettingFactory', function($window) {
         coin: {
           name: "Stellar Network",
           code: "XLM",
-          logo: "stellar.png"
+          logo: "img/rocket.png"
         },
         allowHTTP: true,
         tabs: ["history", "trade", "balance", "send", "trust"]

--- a/src/js/factory.js
+++ b/src/js/factory.js
@@ -78,14 +78,13 @@ myApp.factory('SettingFactory', function($window) {
       return this.NETWORKS[this.getNetworkType()];
     },
     setStellarUrl : function(url) {
-      return $window.localStorage[`network_horizon/${this.getNetworkType()}`] = this.NETWORKS[this.getNetworkType()].defaultHorizon;
+      return $window.localStorage[`network_horizon/${this.getNetworkType()}`] = url || this.NETWORKS[this.getNetworkType()].defaultHorizon;
     },
     getStellarUrl : function() {
       return $window.localStorage[`network_horizon/${this.getNetworkType()}`] || this.setStellarUrl();
     },
     setNetPassphrase : function(val) {
-      //return this.getNetworkType() === 'other' ? $window.localStorage[`network_passphase/${this.getNetworkType()}`] = val : this.NETWORKS[this.getNetworkType()];
-      return $window.localStorage
+      return this.getNetworkType() === 'other' ? $window.localStorage[`network_passphrase/${this.getNetworkType()}`] = val : this.NETWORKS[this.getNetworkType()].networkPassphrase;
     },
     getNetPassphrase : function() {
       return this.getNetworkType() === 'other' ? $window.localStorage[`network_passphrase/${this.getNetworkType()}`] : this.NETWORKS[this.getNetworkType()].networkPassphrase;

--- a/src/js/lang/translate_cn.js
+++ b/src/js/lang/translate_cn.js
@@ -71,7 +71,7 @@ var translate_cn = {
   select_asset : '请先选择要发送的资产。',
   sending_to   : '正在发送到',
   send_done    : '发送成功',
-  not_funded   : '未激活。请发送至少1个XLM创建该账号。最好发3个。',
+  not_funded   : '未激活。请发送至少1个{{code}}创建该账号。最好发3个。',
   can_accept   : '账号可接收',
 
   contacts : '联系人',
@@ -195,7 +195,7 @@ var translate_cn = {
   save     : '保存',
   security : '安全',
   inflation : '通胀地址',
-  inflation_desc : '恒星币每年通胀率为1%。当通胀地址得到的票数超过0.05%的总量时，就能从每周的分发中得到利息。1万个XLM每周约得到2个XLM。',
+  inflation_desc : '恒星币每年通胀率为1%。当通胀地址得到的票数超过0.05%的总量时，就能从每周的分发中得到利息。1万个{{code}}每周约得到2个{{code}}。',
   inflation_done : '通胀地址设置成功',
   inflation_options      : '社区通胀池',
   inflation_options_desc : '你可以加入以下通胀池来得到每周的利息，不同的池子可能会收不同的手续费。',
@@ -210,13 +210,13 @@ var translate_cn = {
   domain_desc : '账号可设置一个域名。在某些场景下，可通过域名取得更多的帮助信息。',
   domain_done : '域名设置成功',
   manage_data : '数据',
-  data_desc1  : '你可以给账号设置任意多的数据项（名称和值），每个数据项都会冻结相应的流明币XLM。',
+  data_desc1  : '你可以给账号设置任意多的数据项（名称和值），每个数据项都会冻结相应的流明币{{code}}。',
   data_desc2  : '数据项可用于各种应用，恒星核心协议并不直接使用它们。',
   data_key    : '名称',
   data_value  : '值',
   data_done   : '数据项设置成功',
   delete_account : '删除账户',
-  merge_desc     : '危险！此操作将你持有的XLM转移到目标账户，你的账户将从账本中删除！',
+  merge_desc     : '危险！此操作将你持有的{{code}}转移到目标账户，你的账户将从账本中删除！',
   dest_account   : '目标账户',
   delete_warning : '我明白所有风险 >>',
   back           : '返回',
@@ -251,6 +251,6 @@ var translate_cn = {
   new_version_available: '发现新版本',
 
   /** Error **/
-  NotFoundError : '恒星网络未找到该账号，请先激活此账号。激活需要至少1 XLM。每个授信和委托单需要额外冻结0.5 XLM，建议至少用3 XLM完成激活。',
-  changeTrustLowReserve : '恒星资金不足，无法授信新资产。每个授信需要额外冻结0.5 XLM。'
+  NotFoundError : '恒星网络未找到该账号，请先激活此账号。激活需要至少1 {{code}}。每个授信和委托单需要额外冻结0.5 {{code}}，建议至少用3 {{code}}完成激活。',
+  changeTrustLowReserve : '恒星资金不足，无法授信新资产。每个授信需要额外冻结0.5 {{code}}。'
 }

--- a/src/js/lang/translate_en.js
+++ b/src/js/lang/translate_en.js
@@ -251,6 +251,6 @@ var translate_en = {
   new_version_available: 'New version available',
 
   /** Error **/
-  NotFoundError : 'The resource was not found. You must have at least 1 lumen in your account for it to be activated! Each trust line or offer requires a 0.5 lumen reserve in addition. To make things easy, send at least 3 lumens to the account.',
+  NotFoundError : 'The resource was not found. You must have at least 1 {{name}} in your account for it to be activated! Each trust line or offer requires a 0.5 {{name}}  reserve in addition. To make things easy, send at least 3 {{name}}s to the account.',
   changeTrustLowReserve : 'Not enough funds to create a new trust line. Each trust line requires a 0.5 lumen reserve in addition.'
 }

--- a/src/js/lang/translate_en.js
+++ b/src/js/lang/translate_en.js
@@ -71,7 +71,7 @@ var translate_en = {
   select_asset : 'Please select an asset to send.',
   sending_to   : 'Sending to',
   send_done    : 'Asset successfully sent.',
-  not_funded   : 'Not funded. To create this account, send it at least 1 lumens (XLM).',
+  not_funded   : 'Not funded. To create this account, send it at least 1 {{name}}s ({{code}}).',
   can_accept   : 'The account can accept',
 
   contacts : 'Contacts',
@@ -175,8 +175,8 @@ var translate_en = {
   settings : 'Settings',
   network  : 'Network',
   proxy    : 'Proxy',
-  switch_net      : 'Stellar Network',
-  switch_net_desc : 'The testnet is for, well, testing. It’s occasionally reset, so don’t get attached to any balances or accounts that you have on it.',
+  switch_net      : 'Switch Stellar Network',
+  switch_net_desc : 'You can switch between different Stellar Network. The testnets are for, well, testing - they are also occasionally reset, so don’t get attached to any balances or accounts that you have on it.',
   public_net : 'Public Network',
   test_net   : 'Test Network',
   other_net  : 'User defined',
@@ -195,7 +195,7 @@ var translate_en = {
   save     : 'Save',
   security : 'Security',
   inflation : 'Inflation Destination',
-  inflation_desc : 'New lumens are added to the network at the rate of 1% each year. Each week, the protocol distributes these lumens to any account that gets over .05% of the “votes” from other accounts in the network.',
+  inflation_desc : 'New {{name}}s are added to the network at the rate of 1% each year. Each week, the protocol distributes these {{name}}s to any account that gets over .05% of the “votes” from other accounts in the network.',
   inflation_done : 'Inflation Destination was set.',
   inflation_options      : 'Inflation pools',
   inflation_options_desc : 'You can join one of the following inflation pools. You can check their website to check the votes and the fee.',
@@ -216,7 +216,7 @@ var translate_en = {
   data_value  : 'Data Entry Value',
   data_done   : 'Data entry was set.',
   delete_account : 'Delete Account',
-  merge_desc     : 'Danger operation! It transfers the native balance (the amount of XLM an account holds) to destination account and removes your account from the ledger.',
+  merge_desc     : 'Danger operation! It transfers the native balance (the amount of {{code}} an account holds) to destination account and removes your account from the ledger.',
   dest_account   : 'Destination Account',
   delete_warning : 'I KNOW EVERYTHING >>',
   back           : 'Back',
@@ -252,5 +252,5 @@ var translate_en = {
 
   /** Error **/
   NotFoundError : 'The resource was not found. You must have at least 1 {{name}} in your account for it to be activated! Each trust line or offer requires a 0.5 {{name}}  reserve in addition. To make things easy, send at least 3 {{name}}s to the account.',
-  changeTrustLowReserve : 'Not enough funds to create a new trust line. Each trust line requires a 0.5 lumen reserve in addition.'
+  changeTrustLowReserve : 'Not enough funds to create a new trust line. Each trust line requires a 0.5 {{name}} reserve in addition.'
 }

--- a/src/js/lang/translate_fr.js
+++ b/src/js/lang/translate_fr.js
@@ -71,7 +71,7 @@ var translate_fr = {
   select_asset : 'Veuillez sélectionner un actif à envoyer.',
   sending_to   : 'Envoyer à',
   send_done    : 'Envoi a bien été exécuté',
-  not_funded   : 'Le compte n\'est pas financé. Pour créer ce compte, vous devez y envoyez au moins 1 lumens (XLM).',
+  not_funded   : 'Le compte n\'est pas financé. Pour créer ce compte, vous devez y envoyez au moins 1 {{name}}s ({{code}}).',
   can_accept   : 'Le compte peut accepter',
 
   contacts : 'Contacts',
@@ -195,10 +195,10 @@ var translate_fr = {
   save     : 'Sauvegarder',
   security : 'Sécurité',
   inflation : 'Destination de l\'inflation',
-  inflation_desc : 'De nouveaux lumens sont ajoutés au réseau à raison de 1% chaque année. Chaque semaine, le protocole distribue ces lumens à n\'importe quel compte qui obtient plus de .05% des "votes" d\'autres comptes dans le réseau.',
+  inflation_desc : 'De nouveaux {{name}}s sont ajoutés au réseau à raison de 1% chaque année. Chaque semaine, le protocole distribue ces {{name}}s à n\'importe quel compte qui obtient plus de .05% des "votes" d\'autres comptes dans le réseau.',
   inflation_done : 'La destination d\'inflation a été configurée.',
   inflation_options      : 'Autres options',
-  inflation_options_desc : 'Vous pouvez rejoindre xlmpool.com pour obtenir les lumens d\'inflation. Ou vous pouvez voter pour RippleFox.',
+  inflation_options_desc : 'Vous pouvez rejoindre xlmpool.com pour obtenir les {{name}}s d\'inflation. Ou vous pouvez voter pour RippleFox.',
   inflation_xlmpool  : 'Votez pour xlmpool.com',
   inflation_lumenaut : 'Votez pour lumenaut.net',
   inflation_moonpool : 'Votez pour MoonPool',
@@ -216,7 +216,7 @@ var translate_fr = {
   data_value  : 'Valeur Saisie de Données',
   data_done   : 'La Saisie de Données a été configurée',
   delete_account : 'Fermer un Compte',
-  merge_desc     : 'ATTENTION! Cette opération va entrainer le transfert du solde (quantité de XLM detenue par le compte) vers un compte destinataire et supprimera le compte du registre',
+  merge_desc     : 'ATTENTION! Cette opération va entrainer le transfert du solde (quantité de {{code}} detenue par le compte) vers un compte destinataire et supprimera le compte du registre',
   dest_account   : 'Compte Destinataire',
   delete_warning : 'JE SUIS INFORMÉ ET CONSCIENT DE MON ACTION >>',
   back           : 'Retour',
@@ -251,6 +251,6 @@ var translate_fr = {
   new_version_available: 'Nouvelle version disponible',
 
   /** Error **/
-  NotFoundError : 'La ressource n\'a pas été trouvée. Vous devez avoir au moins 1 lumen dans votre compte pour qu\'il soit actif! Chaque ligne de confiance ou offre nécessite une réserve de 0.5 lumens suplémentaires. Pour faciliter les choses, envoyez au moins 3 lumens au compte.',
-  changeTrustLowReserve : 'Pas assez de fonds pour créer une nouvelle ligne de confiance. Chaque ligne de confiance nécessite une réserve de 0.5 lumens suplémentaires.'
+  NotFoundError : 'La ressource n\'a pas été trouvée. Vous devez avoir au moins 1 {{name}} dans votre compte pour qu\'il soit actif! Chaque ligne de confiance ou offre nécessite une réserve de 0.5 {{name}}s suplémentaires. Pour faciliter les choses, envoyez au moins 3 {{name}}s au compte.',
+  changeTrustLowReserve : 'Pas assez de fonds pour créer une nouvelle ligne de confiance. Chaque ligne de confiance nécessite une réserve de 0.5 {{name}}s suplémentaires.'
 }

--- a/src/js/stellar/api.factory.js
+++ b/src/js/stellar/api.factory.js
@@ -523,7 +523,6 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
       });
     };
 
-    // option {type:'buy', currency:'XLM', issuer: '', base: 'CNY', base_issuer: 'GXXX', amount: 100, price: 0.01}
     api.offer = function(option, callback) {
       var self = this;
       console.debug('%s %s %s use %s@ %s', option.type, option.amount, option.currency, option.base, option.price);

--- a/src/js/stellar/api.factory.js
+++ b/src/js/stellar/api.factory.js
@@ -71,21 +71,11 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
       return StellarSdk.FederationServer.createForDomain(domain);
     };
 
-    api.setServer = function(url, type, passphrase) {
-      url = url || 'https://horizon.stellar.org';
-      if ('test' == type) {
-        console.debug("TestNetwork: " + url);
-        StellarSdk.Network.useTestNetwork();
-        this.server = new StellarSdk.Server(url, {allowHttp: true});
-      } else if ('other' == type) {
-        console.debug("Use Network: " + url + ', Passphrase: ' + passphrase);
-        StellarSdk.Network.use(new StellarSdk.Network(passphrase));
-        this.server = new StellarSdk.Server(url, {allowHttp: true});
-      } else {
-        console.debug("PublicNetwork: " + url);
-        StellarSdk.Network.usePublicNetwork();
-        this.server = new StellarSdk.Server(url);
-      }
+    api.setServer = function(url, passphrase, allowHttp=false) {
+      if(!url) throw new Error('No URL')
+      console.debug("Use Network: " + url + ', Passphrase: ' + passphrase);
+      StellarSdk.Network.use(new StellarSdk.Network(passphrase));
+      this.server = new StellarSdk.Server(url, {allowHttp});
       history.server = this.server;
       orderbook.server = this.server;
       path.server = this.server;

--- a/src/js/stellar/api.factory.js
+++ b/src/js/stellar/api.factory.js
@@ -152,7 +152,7 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
         callback(err, null);
       });
     };
-    api.sendXLM = function(target, amount, memo_type, memo_value, callback) {
+    api.sendCoin = function(target, amount, memo_type, memo_value, callback) {
       var self = this;
       amount = round(amount, 7);
       self.server.loadAccount(self.address).then(function(account){
@@ -167,14 +167,14 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
         tx.sign(StellarSdk.Keypair.fromSecret(self.seed));
         return self.server.submitTransaction(tx);
       }).then(function(txResult){
-        console.log('Send XLM done.', txResult);
+        console.log(`Send ${$scope.currentNetwork.coin.code} done.`, txResult);
         callback(null, txResult.hash);
       }).catch(function(err){
         console.error('Send Fail !', err);
         callback(err, null);
       });
     };
-    api.sendAsset = function(target, currency, issuer, amount, memo_type, memo_value, callback) {
+    api.sendToken = function(target, currency, issuer, amount, memo_type, memo_value, callback) {
       var self = this;
       amount = round(amount, 7);
       self.server.loadAccount(self.address).then(function(account){
@@ -200,20 +200,20 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
       amount = round(amount, 7);
       console.debug(target, currency, issuer, amount, memo_type, memo_value);
       var self = this;
-      if (currency == 'XLM') {
+      if (currency == $scope.currentNetwork.coin.code) {
         self.isFunded(target, function(err, isFunded){
           if (err) {
             return callback(err, null);
           } else {
             if (isFunded) {
-              self.sendXLM(target, amount, memo_type, memo_value, callback);
+              self.sendCoin(target, amount, memo_type, memo_value, callback);
             } else {
               self.fund(target, amount, memo_type, memo_value, callback);
             }
           }
         });
       } else {
-        self.sendAsset(target, currency, issuer, amount, memo_type, memo_value, callback);
+        self.sendToken(target, currency, issuer, amount, memo_type, memo_value, callback);
       }
     };
 

--- a/src/js/stellar/api.factory.js
+++ b/src/js/stellar/api.factory.js
@@ -621,7 +621,7 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
         issuer = code.issuer;
         code = code.code;
       }
-      return code == 'XLM' ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
+      return code == $scope.currentNetwork.coin.code ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
     }
 
     return api;

--- a/src/js/stellar/history.factory.js
+++ b/src/js/stellar/history.factory.js
@@ -1,6 +1,6 @@
 /* global myApp, StellarSdk */
 
-myApp.factory('StellarHistory', ['$rootScope', function($scope) {
+myApp.factory('StellarHistory', ['$rootScope', 'SettingFactory', function($scope, SettingFactory) {
   var history = {
     server : null
   };
@@ -19,24 +19,30 @@ myApp.factory('StellarHistory', ['$rootScope', function($scope) {
       console.log(data);
       var payments = [];
       data.records.forEach(function(r){
-        var t = { "id": r.id, "type": r.type };
-        switch(r.type){
-        case 'payment':
-          t.isInbound = r.to == address;
-          t.counterparty = t.isInbound ? r.from : r.to;
-          t.asset = r.asset_type == "native" ? {code: "XLM"} : {code:r.asset_code, issuer: r.asset_issuer};
-          t.amount = parseFloat(r.amount);
-          break;
-        case 'create_account':
-          t.isInbound = r.account == address;
-          t.counterparty = t.isInbound ? r.source_account : r.account;
-          t.asset = {code: "XLM"};
-          t.amount = parseFloat(r.starting_balance);
-          break;
-        default:
-
+        var t = {
+          id: r.id,
+          type: r.type,
+          transaction: r.transaction,
+        };
+        switch(r.type) {
+          case 'payment': {
+            t.isInbound = r.to == address;
+            t.counterparty = t.isInbound ? r.from : r.to;
+            t.asset = r.asset_type == "native" ? {code: SettingFactory.getCoin()} : {code:r.asset_code, issuer: r.asset_issuer};
+            t.amount = parseFloat(r.amount);
+            break;
+          }
+          case 'create_account': {
+            t.isInbound = r.account == address;
+            t.counterparty = t.isInbound ? r.source_account : r.account;
+            t.asset = {code: SettingFactory.getCoin()};
+            t.amount = parseFloat(r.starting_balance);
+            break;
+          }
+          default: {
+            // add quite empty line.
+          }
         }
-        t.transaction = r.transaction;
         payments.push(t);
       });
 
@@ -131,7 +137,7 @@ myApp.factory('StellarHistory', ['$rootScope', function($scope) {
       case 'createAccount':
         op.isInbound = op.destination == address;
         op.counterparty = op.isInbound ? tx.source : op.destination;
-        op.asset = {code: "XLM"};
+        op.asset = {code: SettingFactory.getCoin()};
         op.amount = op.startingBalance;
         break;
       case 'pathPayment':

--- a/src/js/stellar/history.factory.js
+++ b/src/js/stellar/history.factory.js
@@ -125,7 +125,8 @@ myApp.factory('StellarHistory', ['$rootScope', 'SettingFactory', function($scope
       operation_count : record.operation_count,
       memo_type : record.memo_type,
       memo : record.memo,
-      resultCode : resultXdr.result().results()[0].value().value().switch().name
+      resultCode : resultXdr.result().results()[0].value().value().switch().name,
+      nativeCode : SettingFactory.getCoin(),
     };
 
     tx.operations.forEach(function(op) {

--- a/src/js/stellar/orderbook.factory.js
+++ b/src/js/stellar/orderbook.factory.js
@@ -1,6 +1,6 @@
 /* global myApp, StellarSdk */
 
-myApp.factory('StellarOrderbook', ['$rootScope', function($scope) {
+myApp.factory('StellarOrderbook', ['$rootScope', function($rootScope) {
   var orderbook = {
     server : null,
     closeBookStream : undefined
@@ -41,7 +41,7 @@ myApp.factory('StellarOrderbook', ['$rootScope', function($scope) {
       issuer = code.issuer;
       code = code.code;
     }
-    return code == 'XLM' ? code : code + '.' + issuer;
+    return code == $rootScope.currentNetwork.coin.code ? code : code + '.' + issuer;
   }
 
   function getAsset(code, issuer) {
@@ -49,7 +49,7 @@ myApp.factory('StellarOrderbook', ['$rootScope', function($scope) {
       issuer = code.issuer;
       code = code.code;
     }
-    return code == 'XLM' ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
+    return code == $rootScope.currentNetwork.coin.code ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
   }
 
   return orderbook;

--- a/src/js/stellar/path.factory.js
+++ b/src/js/stellar/path.factory.js
@@ -42,7 +42,7 @@ myApp.factory('StellarPath', ['$rootScope', function($scope) {
       issuer = code.issuer;
       code = code.code;
     }
-    return code == 'XLM' ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
+    return code == $scope.currentNetwork.coin.code ? new StellarSdk.Asset.native() : new StellarSdk.Asset(code, issuer);
   }
 
   return path;

--- a/src/pages/balance.html
+++ b/src/pages/balance.html
@@ -17,9 +17,9 @@
 				</thead>
 				<tbody>
 					<tr class="BalancesTable__row">
-						<td ng-init="native=currentNetwork.coin">
-							<gateway name="{{native.name}}" logo="{{native.logo}}"
-								website="{{native.website}}" code="{{native.code}}" address=""></gateway>
+						<td ng-init="native=currentNetwork">
+							<gateway name="{{native.name}}" logo="{{native.coin.logo}}"
+								website="{{native.website}}" code="{{native.coin.code}}" address=""></gateway>
 						</td>
 						<td class="BalancesTable__row__amount">
 							<span>{{balance | number : 7}}</span><br>

--- a/src/pages/balance.html
+++ b/src/pages/balance.html
@@ -3,7 +3,7 @@
 	<div class="so-back islandBack islandBack--t">
 		<div class="island">
 			<div class="island__header">
-				{{ 'estimated' | translate}} <strong>{{estimated_value | number : 0}} XLM</strong>
+				{{ 'estimated' | translate}} <strong>{{estimated_value | number : 0}} {{currentNetwork.coin.code}}</strong>
 				<a class="btn btn-success btn-sm" ng-click="refresh()" ng-disabled="working">
 					<span class="glyphicon glyphicon-refresh"></span> {{'refresh' | translate}}</a>
 			</div>
@@ -17,9 +17,9 @@
 				</thead>
 				<tbody>
 					<tr class="BalancesTable__row">
-						<td ng-init="native=gateways.getSourceById('')">
+						<td ng-init="native=currentNetwork.coin">
 							<gateway name="{{native.name}}" logo="{{native.logo}}"
-								website="{{native.website}}" code="XLM" address=""></gateway>
+								website="{{native.website}}" code="{{native.code}}" address=""></gateway>
 						</td>
 						<td class="BalancesTable__row__amount">
 							<span>{{balance | number : 7}}</span><br>
@@ -31,7 +31,7 @@
 				<tbody ng-repeat="(code, sublines) in lines">
 					<tr class="BalancesTable__row" ng-repeat-start="(issuer, line) in sublines">
 						<td ng-init="gateway=gateways.getSourceById(line.issuer)">
-							<gateway name="{{gateway.name}}" logo="{{gateway.logo}}" website="{{gateway.website}}" 
+							<gateway name="{{gateway.name}}" logo="{{gateway.logo}}" website="{{gateway.website}}"
 								code="{{code}}" address="{{line.issuer}}"></gateway>
 						</td>
 						<td class="BalancesTable__row__amount">
@@ -43,7 +43,7 @@
 								ng-hide="line.balance > 0 || isRemoving(line.code, line.issuer)"
 								ng-click="delTrust(line.code, line.issuer)"
 								translate="trust_remove">Remove trust</a>
-							<span class="BalancesTable__row__removeLink" 
+							<span class="BalancesTable__row__removeLink"
 								ng-show="isRemoving(line.code, line.issuer)"
 								translate="trust_removeing">Removing</span><br>
 							<a class="BalancesTable__row__removeLink" href="javascript:"
@@ -61,7 +61,7 @@
 							<div ng-repeat="(key, msg) in deposit_info[code][issuer].info.extra_info">
 								<span>{{key}}: {{msg}}</span><br>
 							</div>
-							
+
 						</td>
 					</tr>
 				</tobdy>

--- a/src/pages/convert.html
+++ b/src/pages/convert.html
@@ -65,7 +65,7 @@
 					<ul>
 						<li ng-repeat="asset in asset.origin.path"
 							ng-switch="asset.asset_type">
-							<span ng-switch-when="native">XLM</span>
+							<span ng-switch-when="native">{{currentNetwork.coin.code}}</span>
 							<span ng-switch-default>{{asset.asset_code}}.{{asset.asset_issuer}}</span>
 						</li>
 					</ul>

--- a/src/pages/header.html
+++ b/src/pages/header.html
@@ -2,14 +2,14 @@
     <header ng-show="!showMenu" class="auth">
       <h1 translate="header_wellcome">Stellar is a platform that connects banks, payments systems, and people.</h1>
     </header>
-    
+
 	<nav class="navbar navbar-inverse" ng-show="showMenu">
 	  <div class="container-fluid">
 	    <div class="navbar-header">
 	      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#myNavbar">
 	        <span class="icon-bar"></span>
 	        <span class="icon-bar"></span>
-	        <span class="icon-bar"></span>                        
+	        <span class="icon-bar"></span>
 	      </button>
 	      <a class="navbar-brand" style="padding-top: 5px;" href="#">
 	      	<img style="width: 40px; height: 40px; border: 2px solid #AAA; border-radius: 50%; background: white;" data-ng-src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAMAAABHPGVmAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAMAUExURUdwTFlqdFpqcVtqckFBQVpqcVppclBwcOK2hFppcVpqcltqclppcVppcVtqcZaWllxqclpqclpqcWNzeFtqcXJ3d5SUlFZfe/GGHFxmcFppcVhrdFppcVtqcltqcFtqcFhnb1tqcVxrc1pqclppcfCHEFppcVpqcZSUlJmZmZeXl+yBFv+GHOyBFux/FltqcllqcVtqceyAFlpqcWRkeFxrc19udltpce6AFu6BFpaWllpqcVtqcVtqcu2BFpaWlpaWlpmZmVtpcZaWlpeXl5eXl5aWllppcVlpce2BF1xpcu2BFu6AFlppcVtqc2Z1fJaWlpaWlltpcqu+xZiYmOyBFpeXl5eXl5eXl5qampaWlpaWluuBFu2DGu2AF+yBFu2AF+yBFu2AFuqCFFtocu2BFuyBFu6CFmR1fl9sdpmZmZSUlO6BGJFyUJeXl+2BFpaWluuAFZWVlZaWlpeXl5aWlpaWluB+H2prZ9zy+Vtqcv7+/u2BF+67GN30+////1ppceD2/VlocN70/FdmblZlbd/1/F5tdVhnb1NialVkbF1sdOH4/tvx+Nrw96G0u6zAx+L4/29/h9nv9s/k69Xr8mRze5Slre1/F/CAFdjt9GZ2fnuNlJyutmBvd7nN1W18hGJxee2GF1xrc7vP19Pp8IeZocXa4crf52l5ge2KF+63GKi7w4qbo3ODik5eZoGSmu69GLTIz2h3f3qKkcjd5JOdon6Pl/G8F+6yGJ6wuJ+xue6kF2t7g7DEy3WFje6sGKa5waO2vuP6/5ipsbrBxL/U28HW3YudpYSVnMfMz1lpc+2UF+2PF+2EF5aosN3z+u6cGMPX3u6oF2V0fdHm7VZmcKy0t1xqcI6gp9ba3PO+Ft3f4YiDV4yWnPSDE+vs7fb394iTmLfL0u6dGMDFyJ6nq8TJzLLGzmdxa6SssOy6Gsx7LOWqHWVsbKeVRMypLH5zXLS7vrKaPe6/GGtzac7j6oCMkubo6dWtKFFkduq5GnFsZc6aK7OaPYmbohy4UwwAAAB5dFJOUwAPLO4B+nIEAfdoxISe3Nt/5o0UUAkGBxIa6SOI/CdWHvBjypIIqtQPEivtBJdDekg4+OMMloj8qXabrzNCLF0+C7ZvZ73s8lrlOs1bvVQ7ztXP/zbejYXIHKmwTx1XfLyIZyVO1/laWW4ZJGq7IPV8XTXytFN6+68Lyom3AAAF0UlEQVRo3u2Yd1wTZxjHTzBLNooMmQLiXkBBBXEUtK7aUnf33nvd9RIu54UsSCBikrIRwnAAKkNxi5sWr25t3R12b7rH3WUj+Sf33qf9I78/c5/PffO8z/P8nvc5CPLII488+p/Ja2TCnHv9/f1CuXm9ICWa74NgWK1aXilH7uACMSjTNwmXqfe0HTdoi7ZpifihwBEhfB+RiijvutlgkhRIKem97wbNGBLEk5V1lZQWkiTMSHqRGAmUMHiEDybfUwTnw3ZJtilThwNkhA7h4c0HyALYSSUynxSACffDFIdK8klnBmxq8h4Erm7nYLV1cH8EDK8vR8CV1yhse6MEvl2lxwhg5RWMNDXQjPwCuBQudki95hDxNCBGTJq6inqzRFplaO1sNdTZU1OolT0DhhEeT1RIYZjsK6/EZCoZLu802SibZYFgGoSP66jKJRvLFDUdJy6d6KjBa2wJylWBca9Yb+QUCZOmJuLKtTxav97At/dZKEWAIDMIQyEMdx8nblzPe4dW3vVf8GO245oEgjEMq26nkt5QU/ORmUFRrsmaGkhL4oeAsJPk2goqI1Ktus3KoChXVLcYiOYkMQwAxBfXlVLvK7ioOO8AOdyiLWSasV7hxZ4RnayqosoXLt5C/OAA+aylQsPYyj6cva0Igol6psELDPinDpDzLQfMBlmbxN4go7HKs+bxVCSvdoA0YzfpnJBVSgBXCR98F3P2VJuUyT+xVdcJZXMfE98WVpMxegk/0Jfvi+n6LA5SfFBZbanhvEvbES19iOQ6eUSG22YVmTxPxIuK4kXJD9osl6xX6g8zHX+4TNHJNHyxVrHYvdMSxPohVmE6hyGiqUdkNR1fdOhVSOtaBruujOdeK4YHptkYiKJOaoeQ8IE2vbJFqW/bbP5VUqH2F7jDWBBvRyCqf6SOY5CUmo7cKrp1xGT+lTxVhmS6ZVQiBwZWWdJ/3JK0rKN3H57g1u0NcRTRpYFdi9yiig91Zzo5MTBdI+makV+hSnbHtkbynCDqrnzXDGmuOs0d/52COKtJ4zoQ8sgZhO8GY6hIFOcdERThPc+cfMVeqetAzupwP3eS/njw5FhmPfCan+oThxDlxa7jKO1UzRGw9cWhMVhtu8vDIiX1RFIsgHkoM7gu37WH1KIM9gwoqbLOddb3ypElIK4o8epcV/Wbf1SP86HBQO5BZzZ3DxiLtLFJkQACQfm9b4/6eOkAywJp0mHIDEDbe+IL3+DVRwtvX0ha6R6KBsIQTrv61ffn5AdN/Rqy8CROQxKAQGZORd/9+tsL58qPOm2i3bswjIbEAYEsRI0fiMXffd6jz3VITHGu1ddGAGA8haK9m8TiHV9evqA8tt62tdfJrZD5ADKyjAmE0oc//qyqvmlee8mGPZgVAmC9WvQk2rufgYh3/Hb590qDRkIXb7PCNgaC2UPSUXTjTrFFf/zd01PdXkBK9+EIQMhjT6Do+5usEPGOv/5EkIr2clwUZYOwX68mTkXR92yMrfuvvvV2nEyp8I+ZYYPEsIY8ijpAfjrda0xPzIwcFegFhfsDK+Hxj6D249q6uxddNpMysxB6EnpZGCLWgYyfQEHQ0wxj08co+tIr9meRZsgoMBDjht07d+7fvdGIotMcv0gFMZDJ7CEP0ZEYjRs29hopxvNO979JNCMIwDeu+1G7pi4SOl/OIihIpIA95IGFNsZdE/s9S1mMIN4LQHjwg+MsiAlhtz1LpdIuAAGBJqaPQ8c9PG3mQBd/EW8KoM9oiWFhYYnCgZ5M5vlBnCvDX8A9JJRt+c4ezv2fhJZP554xK+BZzhmzs+/kGiGElq/hPiVv5IyBoLljOGWsem0WBGXljOaSMTx7BQSNzbmP00Dmvh4CjV7JbeZfDHgVGvzm6hBOIUtfpg4rYCynjOnZVJvcw+1hZQVQlbtmNaeM5wKoopobIOS0eqevEEKrVnKbkKyldJtz2oWQcOks7g1eOFoIeeSRR/+R/gUIJcHACBXGEwAAAABJRU5ErkJggg==">
@@ -17,26 +17,19 @@
 	    </div>
 	    <div class="collapse navbar-collapse" id="myNavbar">
 	      <ul class="nav navbar-nav">
-	        <!-- <li class="dropdown">
-	          <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:">{{'history' | translate}} <span class="caret"></span></a>
-	          <ul class="dropdown-menu">
-	            <li><a href="javascript:" ng-click="goTo('/hist_payments')">{{'payments' | translate}}</a></li>
-	            <li><a href="javascript:" ng-click="goTo('/hist_trades')">{{'trades' | translate}}</a></li>
-	          </ul>
-	        </li> -->
-	        <li ng-class="{active:isActive('/hist_payments') || isActive('/hist_trades') || isActive('/hist_effects')}">
+	        <li ng-class="{active:isActive('/hist_payments') || isActive('/hist_trades') || isActive('/hist_effects')}" ng-show="currentNetwork.tabs.indexOf('history') > -1">
 	        	<a href="javascript:" ng-click="goTo('/hist_payments')">{{'history' | translate}}</a>
 	        </li>
-	        <li ng-class="{active:isActive('/trade') || isActive('/convert')}"><a href="javascript:" ng-click="goTo('/trade')">{{'trade' | translate}}</a></li>
-	        <li ng-class="{active:isActive('/balance')}"><a href="javascript:" ng-click="goTo('/balance')">{{'balance' | translate}}</a></li>
-	        <li ng-class="{active:isActive('/send') || isActive('/contact')}">
+	        <li ng-class="{active:isActive('/trade') || isActive('/convert')}" ng-show="currentNetwork.tabs.indexOf('trade') > -1"><a href="javascript:" ng-click="goTo('/trade')">{{'trade' | translate}}</a></li>
+	        <li ng-class="{active:isActive('/balance')}" ng-show="currentNetwork.tabs.indexOf('balance') > -1"><a href="javascript:" ng-click="goTo('/balance')">{{'balance' | translate}}</a></li>
+	        <li ng-class="{active:isActive('/send') || isActive('/contact')}" ng-show="currentNetwork.tabs.indexOf('send') > -1">
 	        	<a href="javascript:" ng-click="goTo('/send')">{{'send' | translate}}</a>
 	        </li>
-	        <li ng-class="{active:isActive('/trust')}"><a href="javascript:" ng-click="goTo('/trust')">{{'trust' | translate}}</a></li>
-	        <li ng-class="{active:isActive('/bridges')}" ng-show="isPublicNetwork()">
+	        <li ng-class="{active:isActive('/trust')}" ng-show="currentNetwork.tabs.indexOf('trust') > -1"><a href="javascript:" ng-click="goTo('/trust')">{{'trust' | translate}}</a></li>
+	        <li ng-class="{active:isActive('/bridges')}" ng-show="currentNetwork.tabs.indexOf('service') > -1">
 	        	<a href="javascript:" ng-click="goTo('/bridges')">{{'service' | translate}}</a>
 	        </li>
-	        <li ng-class="{active:isActive('/ico')}" ng-show="isPublicNetwork()"><a href="javascript:" ng-click="goTo('/ico')">{{'ico' | translate}}</a></li>
+	        <li ng-class="{active:isActive('/ico')}" ng-show="currentNetwork.tabs.indexOf('ico') > -1"><a href="javascript:" ng-click="goTo('/ico')">{{'ico' | translate}}</a></li>
 	      </ul>
 	      <ul class="nav navbar-nav navbar-right">
 	      	<li ng-show="isTestNetwork()"><a href="javascript:"  ng-click="goTo('/settings')"><i class="fa fa-exclamation-triangle"></i> {{'test_net' | translate}}</a></li>

--- a/src/pages/history_effects.html
+++ b/src/pages/history_effects.html
@@ -6,11 +6,11 @@
 				<a class="btn btn-success btn-sm" ng-click="refresh()" ng-disabled="loading">
 					<span class="glyphicon glyphicon-refresh"></span> {{'refresh' | translate}}</a>
 			</div>
-			
+
 			<div class="AddTrustFromDirectory">
 				<div class="s-alert s-alert--alert" ng-show="error_msg">
 						<ul class="AddTrust__errorList">
-							<li>{{error_msg | translate}}</li>
+							<li>{{error_msg | translate:currentNetwork.coin}}</li>
 						</ul>
 				</div>
             	<table class="table-hover HistoryTable">

--- a/src/pages/history_payments.html
+++ b/src/pages/history_payments.html
@@ -5,12 +5,12 @@
 			<div class="island__header">{{'latest_payments' | translate}}
 				<a class="btn btn-success btn-sm" ng-click="refresh()" ng-disabled="loading">
 					<span class="glyphicon glyphicon-refresh"></span> {{'refresh' | translate}}</a>
-				
+
 			</div>
 			<div class="AddTrustFromDirectory">
 				<div class="s-alert s-alert--alert" ng-show="error_msg">
 						<ul class="AddTrust__errorList">
-							<li>{{error_msg | translate}}</li>
+							<li>{{error_msg | translate:currentNetwork.coin}}</li>
 						</ul>
 				</div>
             	<table class="table-hover HistoryTable">

--- a/src/pages/history_trades.html
+++ b/src/pages/history_trades.html
@@ -6,13 +6,13 @@
 				<a class="btn btn-success btn-sm" ng-click="refresh()" ng-disabled="loading">
 					<span class="glyphicon glyphicon-refresh"></span> {{'refresh' | translate}}</a>
 			</div>
-			
+
 			<div class="s-alert s-alert--alert" ng-show="error_msg">
 					<ul class="AddTrust__errorList">
-						<li>{{error_msg | translate}}</li>
+						<li>{{error_msg | translate:currentNetwork.coin}}</li>
 					</ul>
 			</div>
-			
+
 			<div class="feed">
 				<div ng-repeat="item in trades" ng-switch="item.type">
 					<tx-path-payment ng-switch-when="pathPayment"></tx-path-payment>

--- a/src/pages/home.html
+++ b/src/pages/home.html
@@ -32,7 +32,7 @@
 				<table class="table table-hover" style="border: 1px solid #dedfe0;">
 					<thead>
 						<tr>
-							<td><strong>XLM</strong></td>
+							<td><strong>{{currentNetwork.coin.code}}</strong></td>
 							<td><strong></td>
 							<td class="right"><strong>{{pie.total | number: 0}}</strong></td>
 							<td class="right"><strong>100 %</strong></td>

--- a/src/pages/send.html
+++ b/src/pages/send.html
@@ -9,8 +9,8 @@
 			<div class="AddTrustFromDirectory">
 				<div class="row" ng-init="native=gateways.getSourceById('')">
 					<div class="row__fixedAsset">
-						<gateway name="{{native.name}}" logo="{{native.logo}}"
-								website="{{native.website}}" code="XLM" address=""></gateway>
+						<gateway name="{{currentNetwork.coin.name}}" logo="{{currentNetwork.coin.logo}}"
+								website="{{currentNetwork.website}}" code="{{currentNetwork.coin.code}}" address=""></gateway>
 					</div>
 					<div class="row__shareOption">
 						{{balance | number : 7}}
@@ -18,8 +18,8 @@
 					<div class="row__shareOption">
 						<button class="s-button btn btn-success" 
 							ng-disabled="quote_id"
-							ng-click="pick('XLM', '')">
-							{{'choose' | translate}} XLM</button>
+							ng-click="pickCoin()">
+							{{'choose' | translate}} {{currentNetwork.coin.code}}</button>
 					</div>
 				</div>
 				<div ng-repeat="(code, sublines) in lines">
@@ -34,7 +34,7 @@
 						<div class="row__shareOption">
 							<button class="s-button btn btn-success" 
 								ng-disabled="quote_id"
-								ng-click="pick(line.code, line.issuer)">
+								ng-click="pickToken(line.code, line.issuer)">
 								{{'choose' | translate}} {{line.code}}</button>
 						</div>
 					</div>
@@ -212,7 +212,7 @@
 					
 					<div class="btn-group-pretty" ng-show="asset.amount">
 						<label ng-class="{btn:true, active: isLine(line.code, line.issuer)}"
-							ng-click="pick(line.code, line.issuer)"
+							ng-click="pickToken(line.code, line.issuer)"
 							ng-repeat="line in send"> 
 							<span class="tick"></span>
 							<span class="amount">{{asset.amount | number : 4}}</span>

--- a/src/pages/send.html
+++ b/src/pages/send.html
@@ -9,14 +9,14 @@
 			<div class="AddTrustFromDirectory">
 				<div class="row" ng-init="native=gateways.getSourceById('')">
 					<div class="row__fixedAsset">
-						<gateway name="{{currentNetwork.coin.name}}" logo="{{currentNetwork.coin.logo}}"
+						<gateway name="{{currentNetwork.name}}" logo="{{currentNetwork.coin.logo}}"
 								website="{{currentNetwork.website}}" code="{{currentNetwork.coin.code}}" address=""></gateway>
 					</div>
 					<div class="row__shareOption">
 						{{balance | number : 7}}
 					</div>
 					<div class="row__shareOption">
-						<button class="s-button btn btn-success" 
+						<button class="s-button btn btn-success"
 							ng-disabled="quote_id"
 							ng-click="pickCoin()">
 							{{'choose' | translate}} {{currentNetwork.coin.code}}</button>
@@ -32,7 +32,7 @@
 							{{line.balance | number : 7}}
 						</div>
 						<div class="row__shareOption">
-							<button class="s-button btn btn-success" 
+							<button class="s-button btn btn-success"
 								ng-disabled="quote_id"
 								ng-click="pickToken(line.code, line.issuer)">
 								{{'choose' | translate}} {{line.code}}</button>
@@ -49,16 +49,16 @@
 			<div class="island__paddedContent">
 				<label class="s-inputGroup AddTrust__inputGroup">
 					<span class="s-inputGroup__item s-inputGroup__item--tag S-flexItem-1of4" translate="recipient">Recipient</span>
-					<input type="text" class="s-inputGroup__item S-flexItem-share" 
+					<input type="text" class="s-inputGroup__item S-flexItem-share"
 						ng-model="input_address" ng-change="resolve()" ng-model-options="{ debounce:800}"
 						placeholder="{{'example' | translate}}: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX" list="contacts">
 					<datalist id="contacts">
 						<option ng-repeat="entry in contacts" value="{{entry.name}}">{{entry.address}}</option>
-					</datalist> 
+					</datalist>
 				</label>
 				<label class="s-inputGroup AddTrust__inputGroup">
 					<span class="s-inputGroup__item s-inputGroup__item--tag S-flexItem-1of4" translate="amount">Amount</span>
-					<input type="number" autocomplete="off" class="s-inputGroup__item S-flexItem-share" 
+					<input type="number" autocomplete="off" class="s-inputGroup__item S-flexItem-share"
 						ng-model="asset.amount"
 						ng-disabled="quote_id"
 						placeholder="{{'example' | translate}}: 100.25">
@@ -66,7 +66,7 @@
 
 				<label class="s-inputGroup AddTrust__inputGroup dropdown">
 					<button type="button" class="btn btn-secondary dropdown-toggle s-inputGroup__item s-inputGroup__item--tag S-flexItem-1of4"
-						data-toggle="dropdown" style="padding: 0 1.2em 0 1.2em;" 
+						data-toggle="dropdown" style="padding: 0 1.2em 0 1.2em;"
 						ng-disabled="memo_require || memo_provided || quote_id">
 						<span style="font-size: 18px; font-weight: 700;">{{'memo' | translate}}: {{memo_type}}</span> &nbsp;&nbsp;
 						<span class="caret"></span></button>
@@ -75,13 +75,13 @@
 					      <li><a ng-click="setMemoType('Text')">Memo-Text</a></li>
 					      <li><a ng-click="setMemoType('Hash')">Memo-Hash</a></li>
 					    </ul>
-					<input type="text" class="s-inputGroup__item S-flexItem-share" 
-						ng-model="memo" 
+					<input type="text" class="s-inputGroup__item S-flexItem-share"
+						ng-model="memo"
 						ng-disabled="memo_provided || quote_id"
 						placeholder="{{memo_require ? 'required' : 'optional' | translate}}">
 				</label>
 			</div>
-			
+
 			<div>
 				<div class="island__paddedContent" ng-show="quote_id">
 					<form id="serviceForm" name="serviceForm" role="form">
@@ -93,9 +93,9 @@
 							<div ng-switch-when="text" class="col-xs-12 col-md-10">
 								<label ng-bind="field.label"></label>
 								<p ng-show="field.hint" ng-bind="field.hint" class="field-hint"></p>
-								<input type="text" 
-									ng-model="field.value" 
-									ng-model-options="{debounce:800}" 
+								<input type="text"
+									ng-model="field.value"
+									ng-model-options="{debounce:800}"
 									ng-required="{{field.required}}" class="form-control" />
 							</div>
 							<div ng-switch-when="select" class="col-xs-12 col-md-10">
@@ -121,7 +121,7 @@
 								<div class="amount-wrap">
 									<input type="number" autocomplete="off" placeholder="0.00"
 										class="input amount-big form-control"
-										ng-model="service_amount" 
+										ng-model="service_amount"
 										ng-model-options="{debounce:800}"
 										required="true">
 									<select class="select currency"
@@ -129,27 +129,27 @@
 										ng-change="updateAsset()"
 										ng-disabled = "!mulipleAsset"
 										ng-class="{'disabled': !mulipleAsset}" required="">
-										<option value="{{asset.code}}.{{asset.issuer}}" 
-											ng-repeat="asset in extra_assets" 
+										<option value="{{asset.code}}.{{asset.issuer}}"
+											ng-repeat="asset in extra_assets"
 											ng-selected="service_currency == (asset.code + '.' + asset.issuer)">{{asset.code}}</option>
 									</select>
 								</div>
 							</div>
 						</div>
 					</form>
-					
+
 					<div class="form-group service_alert" ng-show="!serviceForm.$valid && service_currency">
 						<div translate="fill_form">Please fill the form correctly.</div>
 					</div>
 					<div class="form-group service_alert" ng-show="quote_error">
 						<div>{{quote_error}}</div>
 					</div>
-				
+
 					<div class="row form-group brdige_card_code" ng-show="quote_loading">
 						<label><i class="fa fa-spinner fa-pulse"></i> {{'analyzing' | translate}}</label>
 					</div>
 				</div>
-					
+
 				<div class="island__separator"></div>
 				<div class="AddTrust__confirmation">
 					<div class="s-alert s-alert--alert" ng-show="input_address && send_error.hasError()">
@@ -179,7 +179,7 @@
 							<li translate="send_done">Asset successfully sent.</li>
 						</ul>
 					</div>
-					
+
 					<div class="row__message" ng-show="act_loading">
 						<i class="fa fa-spinner fa-pulse"></i> {{'account_loading' | translate}} {{input_address}}
 					</div>
@@ -193,7 +193,7 @@
 					<div class="row__message" style="margin-bottom: 10px;" ng-show="sending">
 						{{'sending_to' | translate}} {{real_address | shortaddress}}
 					</div>
-					
+
 					<!-- <div class="AddTrust__confirmation__assetCard" ng-show="asset.code">
 						<div class="AssetCard AssetCard--fixed">
 							<div class="AssetCard__main">
@@ -209,11 +209,11 @@
 							</div>
 						</div>
 					</div> -->
-					
+
 					<div class="btn-group-pretty" ng-show="asset.amount">
 						<label ng-class="{btn:true, active: isLine(line.code, line.issuer)}"
 							ng-click="pickToken(line.code, line.issuer)"
-							ng-repeat="line in send"> 
+							ng-repeat="line in send">
 							<span class="tick"></span>
 							<span class="amount">{{asset.amount | number : 4}}</span>
 							<div class="btn_card">
@@ -223,17 +223,17 @@
 							</div>
 						</label>
 					</div>
-				
-					<button class="s-button btn btn-success" 
-						ng-show="asset.code" 
-						ng-click="send_asset()" 
+
+					<button class="s-button btn btn-success"
+						ng-show="asset.code"
+						ng-click="send_asset()"
 						ng-disabled="!asset.amount || !isValidAddress(real_address) || sending || (memo_require && !memo)">{{'send' | translate}} {{src_code}}</button>
 				</div>
 			</div>
 
 		</div>
 	</div>
-	
-	
+
+
 	</group>
 </section>

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -48,37 +48,23 @@
 				</div>
 			</div>
 
-
-			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='xlm'">
-				<div class="col-xs-12 col-md-10">
-					<label translate="public_url">Public Net URL</label>
-					<input class="form-control" type="text" ng-model="network_horizon" placeholder="https://horizon.stellar.org" list="nodes"/>
-					<datalist id="nodes">
-						<option value="https://horizon.stellar.org">
-						<option value="https://stellar-api.wancloud.io">
-						<option value="https://api.chinastellar.com">
+			<div class="row" style="margin-bottom: 20px;" ng-init="network = currentNetwork">
+				<div class="col-xs-12 col-md-10" ng-if="all_networks[network_type].knownHorizons.length > 0">
+					<label translate="other_url">Network URL</label>
+					<input class="form-control" type="text" ng-model="network_horizon" placeholder="{{all_networks[network_type].knownHorizons[0]}}" list="horizons"/>
+					<datalist id="horizons">
+						<option ng-repeat="horizon in network.knownHorizons" value="{{horizon}}">
 					</datalist>
 				</div>
-			</div>
-			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='xlmTest'">
-				<div class="col-xs-12 col-md-10">
-					<label translate="test_url">Test Net URL</label>
-					<input class="form-control" type="text" ng-model="network_horizon" placeholder="https://horizon-testnet.stellar.org" list="testnodes"/>
-					<datalist id="testnodes">
-						<option value="https://horizon-testnet.stellar.org">
-					</datalist>
-				</div>
-			</div>
-			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='other'">
-				<div class="col-xs-12 col-md-10">
+				<div class="col-xs-12 col-md-10" ng-if="all_networks[network_type].knownHorizons.length == 0">
 					<label translate="other_url">Network URL</label>
 					<input class="form-control" type="text" ng-model="network_horizon" placeholder="http://horizon.mytestnet.com"/>
 				</div>
-				<div class="col-xs-12 col-md-10">
+				<div class="col-xs-12 col-md-10" ng-if="!all_networks[network_type].networkPassphrase">
 					<label translate="passphrase">Passphrase or id</label>
 					<input class="form-control" type="text" ng-model="network_passphrase" placeholder="My Integration Network ; mycrypto"/>
 				</div>
-				<div class="col-xs-12 col-md-10">
+				<div class="col-xs-12 col-md-10" ng-if="!all_networks[network_type].coin.name">
 					<label translate="coin_ticket">coin ticket</label>
 					<input class="form-control" type="text" ng-model="network_coin" placeholder="XLM"/>
 				</div>

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -6,59 +6,84 @@
 					translate="network">Network</a>
 				<a href="javascript:" ng-class="{active: isMode('federation')}" ng-click="setMode('federation')"
 					translate="fed_protocol">Federation Protocol</a>
+				<a href="javascript:" ng-class="{active: isMode('proxy')}" ng-click="setMode('proxy')"
+					translate="proxy">Proxy</a>
 			</div>
 		</div>
-		
-		<div class="col-sm-9" ng-show="isMode('network')">
+
+		<div class="col-sm-9" ng-show="isMode('proxy')">
 			<div class="row" style="margin-bottom: 20px;">
 				<div class="col-xs-12 col-md-10">
-					<label translate="proxy">Proxy</label> 
+					<label translate="proxy">Proxy</label>
 					<input class="form-control" type="text" ng-model="proxy" placeholder="127.0.0.1:1080" />
 				</div>
 			</div>
-			
+			<div class="row" style="margin-bottom: 20px;">
+				<div class="col-xs-12 col-sm-5">
+					<a class="btn btn-info btn-block btn-big" href="javascript:" ng-click="save('proxy')" translate="save">Save</a>
+				</div>
+			</div>
+		</div>
+		<div class="col-sm-9" ng-show="isMode('network')">
 			<div class="row" style="margin-bottom: 20px;">
 				<div class="col-xs-12 col-md-10">
-					<label translate="switch_net">Stellar Network</label>
+					<label>Selected Stellar Network</label>
+					<ul>
+						<!-- <li><strong>Type: </strong><tt>{{active_network | translate}}</tt></li> -->
+						<li><strong>Passphrase: </strong><tt>{{active_passphrase}}</tt></li>
+						<li><strong>Coin: </strong><tt>{{active_coin}}</tt></li>
+						<li><strong>Horizon: </strong><tt>{{active_horizon}}</tt></li>
+					</ul>
+				</div>
+			</div>
+			<div class="row" style="margin-bottom: 20px;">
+				<div class="col-xs-12 col-md-10">
+					<label translate="switch_net">Switch Stellar Network</label>
 					<p translate="switch_net_desc">The testnet is for, well, testing. It’s occasionally reset, so don’t get attached to any balances or accounts that you have on it.</p>
 					<div class="btn-group">
-						<label class="btn btn-success" ng-class="{active: network_type=='public'}" ng-click="network_type='public'" >{{'public_net' | translate}}</label>
-            			<label class="btn btn-success" ng-class="{active: network_type=='test'}" ng-click="network_type='test'">{{'test_net' | translate}}</label>
-            			<label class="btn btn-success" ng-class="{active: network_type=='other'}" ng-click="network_type='other'">{{'other_net' | translate}}</label>
+						<span ng-repeat="n in all_networks">
+							<button class="btn btn-success" ng-class="{active: network_type == n.networkType}" ng-click="set(n.networkType)">{{n.name}}</button>
+						</span>
 					</div>
 				</div>
 			</div>
-			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='public'">
+
+
+			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='xlm'">
 				<div class="col-xs-12 col-md-10">
-					<label translate="public_url">Public Net URL</label> 
-					<input class="form-control" type="text" ng-model="url" placeholder="https://horizon.stellar.org" list="nodes"/>
+					<label translate="public_url">Public Net URL</label>
+					<input class="form-control" type="text" ng-model="network_horizon" placeholder="https://horizon.stellar.org" list="nodes"/>
 					<datalist id="nodes">
 						<option value="https://horizon.stellar.org">
 						<option value="https://stellar-api.wancloud.io">
 						<option value="https://api.chinastellar.com">
-					</datalist> 
+					</datalist>
 				</div>
 			</div>
-			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='test'">
+			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='xlmTest'">
 				<div class="col-xs-12 col-md-10">
-					<label translate="test_url">Test Net URL</label> 
-					<input class="form-control" type="text" ng-model="test_url" placeholder="https://horizon-testnet.stellar.org" list="testnodes"/>
+					<label translate="test_url">Test Net URL</label>
+					<input class="form-control" type="text" ng-model="network_horizon" placeholder="https://horizon-testnet.stellar.org" list="testnodes"/>
 					<datalist id="testnodes">
 						<option value="https://horizon-testnet.stellar.org">
-					</datalist> 
+					</datalist>
 				</div>
 			</div>
 			<div class="row" style="margin-bottom: 20px;" ng-show="network_type=='other'">
 				<div class="col-xs-12 col-md-10">
-					<label translate="other_url">Network URL</label> 
-					<input class="form-control" type="text" ng-model="other_url" placeholder="http://horizon.mytestnet.com"/>
+					<label translate="other_url">Network URL</label>
+					<input class="form-control" type="text" ng-model="network_horizon" placeholder="http://horizon.mytestnet.com"/>
 				</div>
 				<div class="col-xs-12 col-md-10">
-					<label translate="passphrase">Passphrase or id</label> 
-					<input class="form-control" type="text" ng-model="passphrase" placeholder="My Integration Network ; mycrypto"/>
+					<label translate="passphrase">Passphrase or id</label>
+					<input class="form-control" type="text" ng-model="network_passphrase" placeholder="My Integration Network ; mycrypto"/>
+				</div>
+				<div class="col-xs-12 col-md-10">
+					<label translate="coin_ticket">coin ticket</label>
+					<input class="form-control" type="text" ng-model="network_coin" placeholder="XLM"/>
 				</div>
 			</div>
-			
+
 			<div class="row" style="margin-bottom: 20px;">
 				<div class="col-xs-12 col-sm-5">
 					<a class="btn btn-info btn-block btn-big" href="javascript:" ng-click="save('network')" translate="save">Save</a>
@@ -68,7 +93,7 @@
 				{{network_error}}
 			</div>
 		</div>
-		
+
 		<div class="col-sm-9" ng-show="isMode('federation')">
 			<div class="row" style="margin-bottom: 20px;">
 				<div class="col-xs-12 col-md-10">
@@ -97,6 +122,6 @@
 				</div>
 			</div>
 		</div>
-		
+
 	</div>
 </section>

--- a/src/pages/trade.html
+++ b/src/pages/trade.html
@@ -65,18 +65,18 @@
 					<div class="row" ng-init="native=gateways.getSourceById('')">
 						<div class="row__fixedAsset">
 							<gateway name="{{native.name}}" logo="{{native.logo}}"
-									website="{{native.website}}" code="XLM" address=""></gateway>
+									website="{{native.website}}" code="{{currentNetwork.coin.code}}" address=""></gateway>
 						</div>
 						<div class="row__shareOption">
 							<button class="s-button btn btn-success"
-								ng-click="pick('base', 'XLM', '')"
-								ng-disabled="isBase('XLM', '')"
+								ng-click="pick('base', '{{currentNetwork.coin.code}}', '')"
+								ng-disabled="isBase('{{currentNetwork.coin.code}}', '')"
 								translate="as_base">As Base Asset</button>
 						</div>
 						<div class="row__shareOption">
 							<button class="s-button btn btn-success"
-								ng-click="pick('counter', 'XLM', '')"
-								ng-disabled="isCounter('XLM', '')"
+								ng-click="pick('counter', '{{currentNetwork.coin.code}}', '')"
+								ng-disabled="isCounter('{{currentNetwork.coin.code}}', '')"
 								translate="as_counter">As Counter Asset</button>
 						</div>
 					</div>


### PR DESCRIPTION
In this PR wallet was generalized to nicely handle any Stellar technology based network, not only "Stellar Public Network". For the main point of this PR, please see [src/js/factory.js](https://github.com/stellarchat/desktop-client/compare/master...Factury:networkagnostic?expand=1#diff-2897306a0209c6b19e552379a7e4c095) for list of networks and their properties, and the rest of diff is only about implementing that. In example, change coin's code to "ABC" and **everywhere** "XLM" will become "ABC".

Motivation for this change is to add necessary framework to wallet to later easily integrate [FIC Network](http://ficnetwork.com) and any other upcoming Stellar-based network. We will PR the FIC integration itself separately.

Along the way:
- clarified in code terms asset, coin and tokens. Coin is the native coin of network (i.e. XLM) that doesn't have issuer. Token is anything that someone has issued. Asset is union of two.
- put stellar logo into PNG file
- now translation texts have variables within

Standing problems/confusion:
- `src/js/gateways.js`'s property "specialData" and it's two methods `getSourceBy*` were not about gateways in first place but rather about assets in general and should be moved elsewhere. Now it also obviously duplicates coins within list of networks.
- change of network force-refreshes application.

Manually tested and works for me.