### PR TITLE
Adds support for StellarGuard enabled accounts.

### DIFF
--- a/src/directive/stellarguard-result.html
+++ b/src/directive/stellarguard-result.html
@@ -1,0 +1,10 @@
+<div class="StellarGuard">
+  <p translate="stellarguard_submitted">
+    Your transaction has been submitted to StellarGuard and is awaiting authorization.
+  </p>
+  <p>
+    <a class="btn btn-success btn-md" ng-href="javascript:require('electron').shell.openExternal('{{$ctrl.result.url}}')">
+      <span translate="stellarguard_authorize">Authorize Transaction</span>
+    </a>
+  </p>
+</div>

--- a/src/index.html
+++ b/src/index.html
@@ -66,6 +66,7 @@
   <script src="js/stellar/history.factory.js"></script>
   <script src="js/stellar/orderbook.factory.js"></script>
   <script src="js/stellar/path.factory.js"></script>
+  <script src="js/stellar/stellarguard.factory.js"></script>
 
 </head>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,6 +9,7 @@ myApp.config(function($routeProvider, $httpProvider, $translateProvider, $compil
   $translateProvider.preferredLanguage('cn');
   $translateProvider.useSanitizeValueStrategy('escape');
 
+  $compileProvider.aHrefSanitizationWhitelist(/^\s*(http|https|javascript)/);
   $compileProvider.imgSrcSanitizationWhitelist(/^\s*(local|http|https|app|tel|ftp|file|blob|content|ms-appx|x-wmapp0|cdvfile|chrome-extension):|data:image\//);
 
   $httpProvider.interceptors.push('TokenInterceptor');

--- a/src/js/controller/bridges.js
+++ b/src/js/controller/bridges.js
@@ -139,6 +139,7 @@ myApp.controller("BridgesCtrl", [ '$scope', '$rootScope', '$location', 'SettingF
       $scope.asset = {};
       $scope.quote_error = "";
       $scope.send_done = false;
+      $scope.send_result = null;
       $scope.send_error = '';
     }
 
@@ -268,13 +269,14 @@ myApp.controller("BridgesCtrl", [ '$scope', '$rootScope', '$location', 'SettingF
       $scope.send_error = '';
 
       StellarApi.send($scope.destination, $scope.asset.code, $scope.asset.issuer,
-        $scope.asset.amount, $scope.memo_type, $scope.memo, function(err, hash){
+        $scope.asset.amount, $scope.memo_type, $scope.memo, function(err, result){
           $scope.sending = false;
           if (err) {
             $scope.send_error = StellarApi.getErrMsg(err);
           } else {
             $scope.service_amount = 0;
             $scope.send_done = true;
+            $scope.send_result = result;
           }
           $rootScope.$apply();
         });

--- a/src/js/controller/convert.js
+++ b/src/js/controller/convert.js
@@ -105,10 +105,11 @@ myApp.controller("ConvertCtrl", ['$scope', '$rootScope', 'StellarApi', 'SettingF
     $scope.send_asset = function() {
       $scope.sending = true;
       $scope.send_done = false;
+      $scope.send_result = null;
       $scope.send_error = '';
 
       $scope.asset.max_rate = 1.0001;
-      StellarApi.convert($scope.asset, function(err, hash){
+      StellarApi.convert($scope.asset, function(err, result){
         $scope.sending = false;
 
         if (err) {
@@ -118,6 +119,7 @@ myApp.controller("ConvertCtrl", ['$scope', '$rootScope', 'StellarApi', 'SettingF
           $scope.paths = {};
           $scope.asset = {};
           $scope.send_done = true;
+          $scope.send_result = result;
         }
         $rootScope.$apply();
       });

--- a/src/js/controller/security.js
+++ b/src/js/controller/security.js
@@ -45,13 +45,15 @@ myApp.controller("SecurityCtrl", ['$scope', '$rootScope', 'AuthenticationFactory
     $scope.setInflation = function() {
       $scope.inflation_error = '';
       $scope.inflation_done = false;
+      $scope.inflation_result = null;
       $scope.inflation_working = true;
-      StellarApi.setOption('inflationDest', $scope.inflation, function(err, hash){
+      StellarApi.setOption('inflationDest', $scope.inflation, function(err, result){
         $scope.inflation_working = false;
         if (err) {
           $scope.inflation_error = StellarApi.getErrMsg(err);
         } else {
           $scope.inflation_done = true;
+          $scope.inflation_result = result;
         }
         $scope.$apply();
       });
@@ -81,13 +83,15 @@ myApp.controller("SecurityCtrl", ['$scope', '$rootScope', 'AuthenticationFactory
     $scope.setDomain = function() {
       $scope.domain_error = '';
       $scope.domain_done = false;
+      $scope.domain_result = null;
       $scope.domain_working = true;
-      StellarApi.setOption('homeDomain', $scope.domain, function(err, hash){
+      StellarApi.setOption('homeDomain', $scope.domain, function(err, result){
         $scope.domain_working = false;
         if (err) {
           $scope.domain_error = StellarApi.getErrMsg(err);
         } else {
           $scope.domain_done = true;
+          $scope.domain_result = result;
         }
         $scope.$apply();
       });
@@ -103,7 +107,8 @@ myApp.controller("SecurityCtrl", ['$scope', '$rootScope', 'AuthenticationFactory
       $scope.data_error = '';
       $scope.data_done = false;
       $scope.data_working = true;
-      StellarApi.setData($scope.data_key, $scope.data_value, function(err, hash){
+      $scope.data_result = null;
+      StellarApi.setData($scope.data_key, $scope.data_value, function(err, result){
         $scope.data_working = false;
         if (err) {
           $scope.data_error = StellarApi.getErrMsg(err);
@@ -114,6 +119,7 @@ myApp.controller("SecurityCtrl", ['$scope', '$rootScope', 'AuthenticationFactory
             delete $scope.data_attr[$scope.data_key];
           }
           $scope.data_done = true;
+          $scope.data_result = result;
         }
         $scope.$apply();
       });
@@ -127,7 +133,7 @@ myApp.controller("SecurityCtrl", ['$scope', '$rootScope', 'AuthenticationFactory
       $scope.merge_error = '';
       $scope.merge_done = false;
       $scope.merge_working = true;
-      StellarApi.merge($scope.dest_account, function(err, hash){
+      StellarApi.merge($scope.dest_account, function(err, result){
         $scope.merge_working = false;
         if (err) {
           $scope.merge_error = StellarApi.getErrMsg(err);
@@ -135,6 +141,7 @@ myApp.controller("SecurityCtrl", ['$scope', '$rootScope', 'AuthenticationFactory
           $rootScope.balance = 0;
           $rootScope.reserve = 0;
           $scope.merge_done = true;
+          $scope.merge_result = result;
         }
         $scope.$apply();
       });

--- a/src/js/controller/send.js
+++ b/src/js/controller/send.js
@@ -335,15 +335,17 @@ myApp.controller("SendCtrl", ['$scope', '$rootScope', '$routeParams', 'StellarAp
     $scope.send_asset = function() {
       $scope.sending = true;
       $scope.send_done = false;
+      $scope.send_result = null;
       $scope.send_error.message = '';
 
       StellarApi.send($scope.real_address, $scope.asset.code, $scope.asset.issuer,
-        $scope.asset.amount, $scope.memo_type, $scope.memo, function(err, hash){
+        $scope.asset.amount, $scope.memo_type, $scope.memo, function(err, result){
           $scope.sending = false;
 
           if (err) {
             $scope.send_error.message = StellarApi.getErrMsg(err);
           } else {
+            $scope.send_result = result;
             $scope.service_amount = 0;
             $scope.asset.amount = 0;
             $scope.send_done = true;

--- a/src/js/controller/trade.js
+++ b/src/js/controller/trade.js
@@ -256,6 +256,7 @@ myApp.controller("TradeCtrl", [ '$scope', '$rootScope', 'StellarApi', 'StellarOr
       $scope[type + 'ing'] = true;
       $scope[type + '_ok'] = false;
       $scope[type + '_fail'] = "";
+      $scope[type + '_result'] = null;
       var option = {
         type : type,
         currency : $scope.base_code,
@@ -270,12 +271,13 @@ myApp.controller("TradeCtrl", [ '$scope', '$rootScope', 'StellarApi', 'StellarOr
         option.amount = $scope.sell_amount;
         option.price  = $scope.sell_price;
       }
-      StellarApi.offer(option, function(err, hash) {
+      StellarApi.offer(option, function(err, result) {
         $scope[type + 'ing'] = false;
         if (err) {
           $scope[type + '_fail'] = StellarApi.getErrMsg(err);
         } else {
           $scope[type + '_ok'] = true;
+          $scope[type + '_result'] = result;
           $scope[type + '_amount'] = "";
           $scope[type + '_price'] = "";
           $scope[type + '_volume'] = "";
@@ -309,9 +311,12 @@ myApp.controller("TradeCtrl", [ '$scope', '$rootScope', 'StellarApi', 'StellarOr
         offer.buying  = getAsset($scope.offers.all[offer_id].buy_code, $scope.offers.all[offer_id].buy_issuer);
       }
       $scope.cancel_error = "";
-      StellarApi.cancel(offer, function(err, hash){
+      $scope.cancel_result = null;
+      StellarApi.cancel(offer, function(err, result){
         if (err) {
           $scope.cancel_error = StellarApi.getErrMsg(err);
+        } else {
+          $scope.cancel_result = result;
         }
         $scope.refreshOffer();
       });

--- a/src/js/directives.js
+++ b/src/js/directives.js
@@ -275,3 +275,9 @@ myApp.directive('strongPassword', function () {
   };
 });
 
+myApp.component('stellarguardResult', {
+  templateUrl: 'directive/stellarguard-result.html',
+  bindings: {
+    result: '<'
+  }
+});

--- a/src/js/lang/translate_en.js
+++ b/src/js/lang/translate_en.js
@@ -255,6 +255,10 @@ var translate_en = {
   logout : 'Logout',
   new_version_available: 'New version available',
 
+  /** StellarGuard **/
+  stellarguard_submitted: 'Your transaction has been submitted to StellarGuard and is awaiting authorization.',
+  stellarguard_authorize: 'Authorize Transaction',
+
   /** Error **/
   NotFoundError : 'The resource was not found. You must have at least 1 {{name}} in your account for it to be activated! Each trust line or offer requires a 0.5 {{name}}  reserve in addition. To make things easy, send at least 3 {{name}}s to the account.',
   changeTrustLowReserve : 'Not enough funds to create a new trust line. Each trust line requires a 0.5 {{name}} reserve in addition.'

--- a/src/js/stellar/stellarguard.factory.js
+++ b/src/js/stellar/stellarguard.factory.js
@@ -1,0 +1,32 @@
+/* global myApp */
+
+myApp.factory('StellarGuard', ['SettingFactory', '$http', function(SettingFactory, $http) {
+  const STELLARGUARD_PUBLIC_KEY = 'GCVHEKSRASJBD6O2Z532LWH4N2ZLCBVDLLTLKSYCSMBLOYTNMEEGUARD';
+
+  return {
+    hasStellarGuard(account) {
+      return account.signers.some(function(signer) {
+        return signer.public_key === STELLARGUARD_PUBLIC_KEY;
+      });
+    },
+
+    submitTransaction(transaction) {
+      const url = this._getUrl('transactions');
+      const xdr = transaction.toEnvelope().toXDR('base64');
+      return $http.post(url, {xdr: xdr})
+        .then(function(res) {
+          console.log(res);
+          return res.data;
+        });
+    },
+
+    _getUrl(path) {
+      let host = 'stellarguard.me';
+      if(SettingFactory.getNetworkType() !== 'xlm') {
+        host = 'test.stellarguard.me';
+      }
+
+      return `https://${host}/api/${path}`;
+    }
+  };
+} ]);

--- a/src/pages/bridges.html
+++ b/src/pages/bridges.html
@@ -200,7 +200,8 @@
 				</div>
 				
 				<div class="service_success" ng-show="send_done">
-					<div translate="send_done">Asset successfully sent.</div>
+					<stellarguard-result ng-if="send_result.stellarGuard" result="send_result"></stellarguard-result>
+					<div ng-hide="send_result.stellarGuard" translate="send_done">Asset successfully sent.</div>
 				</div>
 				
 			</div>

--- a/src/pages/convert.html
+++ b/src/pages/convert.html
@@ -76,7 +76,8 @@
 				</div>
 				
 				<div class="service_success" ng-show="send_done">
-					<div translate="send_done">Asset successfully sent.</div>
+					<stellarguard-result ng-if="send_result.stellarGuard" result="send_result"></stellarguard-result>
+					<div ng-hide="send_result.stellarGuard" translate="send_done">Asset successfully sent.</div>
 				</div>
 			</div>
 		</div>

--- a/src/pages/security.html
+++ b/src/pages/security.html
@@ -56,7 +56,10 @@
 			<div class="s-alert s-alert--alert row__message" ng-show="inflation_error">
 				{{inflation_error}}
 			</div>
-			<div class="s-alert s-alert--success row__message" ng-show="inflation_done" translate="inflation_done">
+			<div class="s-alert s-alert--success row__message" ng-if="inflation_done && inflation_result.stellarGuard">
+				<stellarguard-result result="inflation_result"></stellarguard-result>
+			</div>
+			<div class="s-alert s-alert--success row__message" ng-show="inflation_done && !inflation_result.stellarGuard" translate="inflation_done">
 				Inflation Destination was set.
 			</div>
 			<div class="row" style="margin-bottom: 20px;">
@@ -103,7 +106,10 @@
 			<div class="s-alert s-alert--alert row__message" ng-show="domain_error">
 				{{domain_error}}
 			</div>
-			<div class="s-alert s-alert--success row__message" ng-show="domain_done" translate="domain_done">
+			<div class="s-alert s-alert--success row__message" ng-if="domain_done && domain_result.stellarGuard">
+				<stellarguard-result result="domain_result"></stellarguard-result>
+			</div>
+			<div class="s-alert s-alert--success row__message" ng-show="domain_done && !domain_result.stellarGuard" translate="domain_done">
 				Home Domain was set.
 			</div>
 			<div class="row" style="margin-bottom: 20px;">
@@ -130,7 +136,10 @@
 			<div class="s-alert s-alert--alert row__message" ng-show="data_error">
 				{{data_error}}
 			</div>
-			<div class="s-alert s-alert--success row__message" ng-show="data_done" translate="data_done">
+			<div class="s-alert s-alert--success row__message" ng-if="data_done && data_result.stellarGuard">
+				<stellarguard-result result="domain_result"></stellarguard-result>
+			</div>
+			<div class="s-alert s-alert--success row__message" ng-show="data_done && !data_result.stellarGuard" translate="data_done">
 				Data entry was set.
 			</div>
 			<div class="row" style="margin-bottom: 20px;">
@@ -163,7 +172,10 @@
 			<div class="s-alert s-alert--alert row__message" ng-show="merge_error">
 				{{merge_error}}
 			</div>
-			<div class="s-alert s-alert--success row__message" ng-show="merge_done" translate="merge_done">
+			<div class="s-alert s-alert--success row__message" ng-if="merge_done && merge_result.stellarGuard">
+				<stellarguard-result result="merge_result"></stellarguard-result>
+			</div>
+			<div class="s-alert s-alert--success row__message" ng-show="merge_done && !merge_result.stellarGuard" translate="merge_done">
 				Your account was merged to destination.
 			</div>
 			<div class="row" style="margin-bottom: 20px;" ng-show="delete_warning">

--- a/src/pages/send.html
+++ b/src/pages/send.html
@@ -177,7 +177,10 @@
 					</div>
 					<div class="s-alert s-alert--success" ng-show="send_done">
 						<ul class="AddTrust__errorList">
-							<li translate="send_done">Asset successfully sent.</li>
+							<li ng-if="send_result.stellarGuard">
+								<stellarguard-result result="send_result"></stellarguard-result>
+							</li>
+							<li ng-hide="send_result.stellarGuard" translate="send_done">Asset successfully sent.</li>
 						</ul>
 					</div>
 

--- a/src/pages/trade.html
+++ b/src/pages/trade.html
@@ -136,7 +136,10 @@
 							<div class="OfferMaker__youHave">
 								{{'you_have' | translate}} {{getBalance(counter_code, counter_issuer)}} {{counter_code}}
 							</div>
-							<div class="s-alert s-alert--success OfferMaker__message" ng-show="buy_ok" translate="offer_success">Offer successfully created</div>
+							<div class="s-alert s-alert--success OfferMaker__message" ng-if="buy_ok && buy_result.stellarGuard">
+								<stellarguard-result result="buy_result"></stellarguard-result>
+							</div>
+							<div class="s-alert s-alert--success OfferMaker__message" ng-show="buy_ok && !buy_result.stellarGuard" translate="offer_success">Offer successfully created</div>
 							<div class="s-alert s-alert--error OfferMaker__message" ng-show="buy_fail">{{buy_fail}}</div>
 							<button class="s-button btn btn-success" ng-click="offer('buy')" ng-disabled="buying">{{'buy' | translate}} {{base_code}}</button>
 						</div>
@@ -172,7 +175,10 @@
 							<div class="OfferMaker__youHave">
 								{{'you_have' | translate}} {{getBalance(base_code, base_issuer)}} {{base_code}}
 							</div>
-							<div class="s-alert s-alert--success OfferMaker__message" ng-show="sell_ok" translate="offer_success">Offer successfully created</div>
+							<div class="s-alert s-alert--success OfferMaker__message" ng-if="sell_ok && sell_result.stellarGuard">
+								<stellarguard-result result="sell_result"></stellarguard-result>
+							</div>
+							<div class="s-alert s-alert--success OfferMaker__message" ng-show="sell_ok && !sell_result.stellarGuard" translate="offer_success">Offer successfully created</div>
 							<div class="s-alert s-alert--error OfferMaker__message" ng-show="sell_fail">{{sell_fail}}</div>
 							<button class="s-button btn btn-success" ng-click="offer('sell')" ng-disabled="selling">{{'sell' | translate}} {{base_code}}</button>
 						</div>


### PR DESCRIPTION
When submitting a transaction, checks if the account is StellarGuard enabled (has a particular signer). If so, submits to StellarGuard instead of to Horizon.

See https://stellarguard.me for details about the service.

For non-StellarGuard accounts, no change is made.

Closes #238 