### PR TITLE
Add backend support for Ledger hardware wallet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
         "es6": true,
     },
     "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2017,
+    },
     "plugins": [
         "html"
     ],

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Foxlet Wallet uses [Electron](http://electronjs.org/) to create an application. 
 - reload UI with CTRL+R to refresh front-end code
 - restart `yarn start` process to refresh back-end code
 
+## Ledger
+
+If you have permission problems on Linux, this may help:
+```sh
+echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/99-hidraw-permissions.rules
+```
+
+If you have more problems, make sure that:
+1. Ledger is connected.
+2. Ledger is unlocked.
+3. Ledger has Stellar app installed.
+4. Ledger currently is in the Stellar app.
+5. Ledger Stellar app settings has "browser support" set to "No".
+
 
 # Foxlet恒星钱包 🚀
 

--- a/main.js
+++ b/main.js
@@ -31,7 +31,9 @@
     var win = new BrowserWindow({
       width: 1280,
       height: 800,
-      frame: false
+      frame: true,
+      minWidth: 800,
+      minHeight: 600
     })
     win.loadURL('file://' + __dirname + '/src/index.html')
     win.on('closed', onClosed)

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "underscore": "^1.9.1"
   },
   "devDependencies": {
+    "@ledgerhq/hw-app-str": "^4.15.0",
+    "@ledgerhq/hw-transport-node-hid": "^4.15.0",
+    "babel-runtime": "^6.26.0",
     "concurrently": "^3.5.1",
     "devtron": "^1.4.0",
     "electron": "2.0.2",

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,0 +1,25 @@
+/*global module */
+
+module.exports = {
+
+  HWW_STATE: {
+    OFFLINE: 'offline',  // After removing cable and "remove" event.
+    SLEEP: 'sleep',  // After timeout when PIN has to be entered again.
+    ONLINE: 'online',  // After PIN but before Stellar app (usually after "add" event).
+    AVAILABLE: 'available',  // inside Stellar app but not yet confirmed subaccount.
+    READY: 'ready',  // inside Stellar app and selected subaccount.
+  },
+
+  HWW_API: {
+    CONFIG: 'HardwareWallet.getAppConfig',
+    DESELECT: 'HardwareWallet.deselectSubaccount',
+    LIST: 'HardwareWallet.list',
+    LISTEN: 'HardwareWallet.listen',
+    PK: 'hardwareWallet.getPublicKey',
+    SELECT: 'HardwareWallet.selectSubaccount',
+    SIGN_HASH: 'hardwareWallet.signHash',
+    SIGN_TE: 'hardwareWallet.signTransaction',
+    SUPPORT: 'HardwareWallet.isSupported',
+  },
+
+}

--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="css/trade.css">
 
   <script>/*global require */ window.$ = window.jQuery = require('../node_modules/jquery/dist/jquery.min.js');</script>
+  <script>/*global require */ window.CONST = require('./common/constants.js');</script>
   <script src="../node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
   <script src="../node_modules/angular/angular.min.js"></script>
   <script src="../node_modules/angular-route/angular-route.min.js"></script>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,4 +1,4 @@
-/* globals angular, gateways, nw, translate_cn, translate_en, translate_fr, */
+/* globals angular, gateways, ipcRenderer, nw, translate_cn, translate_en, translate_fr, */
 /* exported myApp */
 var myApp = angular.module('myApp', ['ngRoute', 'pascalprecht.translate', 'chart.js', 'monospaced.qrcode']);
 
@@ -253,6 +253,19 @@ myApp.run(['$rootScope', '$window', '$location', '$translate', 'AuthenticationFa
 
     $rootScope.isLangCN = function() {
       return SettingFactory.getLang() == 'cn';
+    }
+    $rootScope.invokeIPC = async (channel, ...args) => {
+      const _id = Math.floor(Math.random()*10000);
+      const promise = new Promise((resolve, reject)=>{
+        const cb = (event, id, err, result) => {
+          if(id!==_id) return;
+          ipcRenderer.removeListener(channel, cb);
+          if(err) { reject(err) } else { resolve(result) }
+        }
+        ipcRenderer.on(channel, cb)
+      })
+      ipcRenderer.send(channel, _id, ...args)
+      return promise;
     }
 
     $translate.use(SettingFactory.getLang());

--- a/src/main/hardwareWalletLedger.js
+++ b/src/main/hardwareWalletLedger.js
@@ -1,0 +1,352 @@
+/*global module, Buffer, require */
+module.exports = (()=>{
+  'use strict';
+
+  const { default: Transport } = require("@ledgerhq/hw-transport-node-hid");
+  const { default: Str } = require("@ledgerhq/hw-app-str");
+  const { Keypair, xdr } = require("stellar-sdk");
+  const BigNumber = require('bignumber.js')
+  const {sha256} = require("sha.js");
+
+  const {HWW_STATE} = require('../common/constants')
+
+
+  //// Helpers
+  const hash = (data) => {
+    let hasher = new sha256();
+    hasher.update(data, 'utf8');
+    return hasher.digest();
+  }
+
+  const parseSubaccount = (_subaccount) => {
+      const subaccount = new BigNumber(_subaccount);
+      if(!subaccount.isFinite()) throw new Error(`Not a number: ${subaccount.toString()}`)
+      if(subaccount.isNegative()) throw new Error(`Not a positive integer: ${subaccount.toString()}`)
+      if(subaccount.dp() > 0) throw new Error(`Not a whole integer: ${subaccount.toString()}`)
+      return subaccount.toString();
+  }
+
+
+  /**
+   * HardwareWalletLedger provides high-level API for Ledger device with Stellar app.
+   *
+   * As it turns out Ledger behaviour is "pretty random" that depends on timing of interactions and computer's OS.
+   * Furthermore it lacks full introspection about which state it is in and whenever it's available for signing.
+   * This class creates wrapper with less random behaviour and provide more information of the current state.
+   *
+   * Class listens for added or removed Ledgers and manages a list of instances for each unique Ledger device. It also
+   * informs intances whenever its Ledger has gone offline or came back online. From there, each instance monitors
+   * itself via watchdog that tries to get public key and figures out current state based on success or error messages.
+   *
+   * High-level wrapper provide the following benefits:
+   * - more granual states (as discussed above)
+   * - less inconsistent behaviour across Linux and MacOS (it still has minor problems, and Windows is untested)
+   * - request queue to solve "Ledger is busy" errors
+   * - "selected subaccount" to mimic "login workflow" and so methods wont need it as explicit parameter
+   *
+   * @class HardwareWalletLedger
+   */
+  class HardwareWalletLedger {
+
+    constructor(uid, device) {
+      this.uid = uid;
+      this.device = device;
+      this.descriptor = undefined;
+      this.transport = undefined;
+      this.watchdog = undefined;
+      this.subaccount = undefined;  // Set with `this.selectSubaccount('0');`
+      this.publicKey = undefined;   // Set with `this.selectSubaccount('0');`
+      this.queue = Promise.resolve();
+      this.busy = false;
+    }
+
+    async deconstructor() {
+      await this._changeState(HWW_STATE.OFFLINE)
+      console.info(`Hardwallet<${this.uid}> deconstructed.`)
+    }
+
+    assertState(...states) {
+      if(!states.includes(this.state)) throw new Error(`Hardwallet<${this.uid}>: Active state is '${this.state}', but required any of ${states}`)
+    }
+
+    async _changeState(newState, ...args) {
+      if(!newState || this.state === newState) return;
+      switch(newState) {
+        case(HWW_STATE.OFFLINE   ): {await this._goOffline(   ...args); break; }
+        case(HWW_STATE.SLEEP     ): {await this._goSleep(     ...args); break; }
+        case(HWW_STATE.ONLINE    ): {await this._goOnline(    ...args); break; }
+        case(HWW_STATE.AVAILABLE ): {await this._goAvailable( ...args); break; }
+        case(HWW_STATE.READY     ): {await this._goReady(     ...args); break; }
+        default: {
+          throw new Error(`Hardwallet<${this.uid}>: Internal error - unrecognized state '${newState}'`)
+        }
+      }
+
+      await Promise.all([HardwareWalletLedger.listeners.map((cb)=>cb(this.uid, newState, this.state, HardwareWalletLedger.list()))]);
+      console.info(`Hardwallet<${this.uid}> State: ${this.state||''} -> ${newState}`)
+      this.state = newState;
+    }
+
+    async _goOffline() {
+      this.descriptor = undefined;
+      if(this.watchdog) {
+        clearInterval(this.watchdog);
+        this.watchdog = undefined;
+        console.info(`Hardwallet<${this.uid}> Watchdog: stopped.`)
+      }
+
+      if(this.transport) {
+        try {
+          await this.transport.close();
+          this.transport = undefined;
+          this.str = undefined;
+          this.busy = false;
+          console.info(`Hardwallet<${this.uid}>: Transport closed.`)
+        } catch(e) {
+          console.error(`Hardwallet<${this.uid}>failed to close transport`, e)
+        }
+      }
+    }
+
+    async _goOnline(descriptor) {
+      this.descriptor = descriptor;
+      if(!this.watchdog) {
+        this.watchdog = setInterval(()=>this._watchdogCallback(), 2000)
+        console.info(`Hardwallet<${this.uid}> Watchdog: started.`)
+        this._watchdogCallback();
+      }
+    }
+
+    async _goSleep() {
+      // Nothing special to do in backend, but frontend would love to learn about this.
+    }
+
+    async _goAvailable() {
+      // Nothing special to do in backend, but frontend would love to learn about this.
+    }
+
+    async _goReady() {
+      // Nothing special to do in backend, but frontend would love to learn about this.
+    }
+
+    async _watchdogCallback() {
+      console.log(`Hardwallet<${this.uid}> Watchdog: state='${this.state}' busy='${this.busy}'`)
+      if(!this.transport) {
+        try {
+          const transport = await Transport.open(this.descriptor);
+          const str = new Str(transport);
+          this.transport = transport;
+          this.str = str;
+          console.info(`Hardwallet<${this.uid}>: Transport open.`)
+        } catch(e) {
+          console.warn(`Hardwallet<${this.uid}> Watchdog: recovering from error... (${e.message})`)
+          return;  // Skip the rest try again later.
+        }
+      }
+
+      let newState;
+      try {
+
+        if(this.subaccount) {
+          if(!this.publicKey && !this.busy) await this.selectSubaccount(this.subaccount)
+          if(!this.busy) await this.ping();
+          newState = HWW_STATE.READY;
+        } else {
+          if(!this.busy && await this.ping()) newState = HWW_STATE.AVAILABLE;
+        }
+
+      } catch(err) {
+
+        // After PIN, outside Stellar app, if calling `this.str.getAppConfiguration`
+        if(err.statusCode === 27904 && err.statusText === 'INS_NOT_SUPPORTED') {
+          newState = HWW_STATE.ONLINE;
+
+        // After PIN, outside Stellar app, if calling `this.str.getPublicKey`.
+        } else if(err.statusCode === 26368 && err.statusText === 'INCORRECT_LENGTH') {
+          newState = HWW_STATE.ONLINE;
+
+        // During sleep.
+        } else if(err.statusCode === 26628 && err.statusText === 'UNKNOWN_ERROR') {
+          newState = HWW_STATE.SLEEP;
+
+        // If Ledger has changed path at random reconnect.
+        } else if(err.message === 'Invalid channel' || err.message === 'Cannot write to HID device') {
+          newState = HWW_STATE.ONLINE;
+          try {
+            await this.transport.close();
+            this.transport = undefined;
+            this.str = undefined;
+            console.warn(`Hardwallet<${this.uid}> Transport closed.`)
+          } catch(e) {
+            console.error(`Hardwallet<${this.uid}> failed to close transport:`, e)
+          }
+
+        // ... else let the user know (if application was open from terminal).
+        } else { console.error(`Hardwallet<${this.uid}> Watchdog got unrecognized Error: code=${err.statusCode} text="${err.statusText}" message="${err.message}"`) }
+      }
+
+      try {
+        this._changeState(newState);
+      } catch(err) {
+        console.error(`Hardwallet<${this.uid}> Watchdog: Internal error during changing state to '${newState}': `, err)
+      }
+    }
+
+    async _selectSubaccount(_subaccount) {
+      this.assertState(HWW_STATE.AVAILABLE);
+      const subaccount = parseSubaccount(_subaccount);
+      const publicKey = await this._getPublicKey(subaccount, true);
+      this.subaccount = subaccount.toString();
+      this.publicKey = publicKey;
+      await this._changeState(HWW_STATE.READY);
+      return this.publicKey;
+    }
+
+    async _deselectSubaccount(_subaccount) {
+      this.assertState(HWW_STATE.OFFLINE, HWW_STATE.SLEEP, HWW_STATE.ONLINE, HWW_STATE.READY);
+      this.subaccount = undefined;
+      this.publicKey = undefined;
+      if(this.state === HWW_STATE.READY) await this._changeState(HWW_STATE.AVAILABLE);
+      return undefined;
+    }
+
+    async _getAppConfig() {
+      this.assertState(HWW_STATE.AVAILABLE, HWW_STATE.READY);
+      const result = await this.str.getAppConfiguration();
+      return result;
+    }
+
+    async _getPublicKey(_subaccount, display) {
+      this.assertState(HWW_STATE.AVAILABLE, HWW_STATE.READY);
+      if(_subaccount === undefined) {
+        return this.publicKey;
+      } else if(typeof _subaccount === 'string' || typeof _subaccount === 'number') {
+        return (await this.str.getPublicKey(`44'/148'/${parseSubaccount(_subaccount)}'`, true, display?true:false)).publicKey;
+      } else if(Array.isArray(_subaccount)) {
+        const all = [];
+        for(const sub of _subaccount) {
+          all.push((await this.str.getPublicKey(`44'/148'/${parseSubaccount(sub)}'`, true, display?true:false)).publicKey);
+        }
+        return all
+      } else {
+        throw new Error('catch me')
+      }
+    }
+
+    async _signTe(teSignatureBaseSerialized) {
+      this.assertState(HWW_STATE.READY);
+      const signatureWrapper = await this.str.signTransaction(`44'/148'/${this.subaccount}'`, Buffer.from(teSignatureBaseSerialized, 'base64'));
+
+      // add signature to transaction
+      const keyPair = Keypair.fromPublicKey(this.publicKey);
+      const hint = keyPair.signatureHint();
+      const decoratedSignature = new xdr.DecoratedSignature({hint: hint, signature: signatureWrapper.signature});
+
+      return decoratedSignature.toXDR().toString('base64');
+    }
+
+    async _signHash(teHashSerialized) {
+      // Less secure than `signTe` and handles any transactions, but we don't have such usecase yet. TODO: Implement later.
+      this.assertState(HWW_STATE.READY);
+      throw new Error('TODO: Implement.');
+    }
+
+    async _ping() {
+      // FYI If Ledger Nano is asleep, then getPublicKey errors but getAppConfig keeps working. Also without verification is 3x faster.
+      return await this.str.getPublicKey(`44'/148'/0'`, false, false);
+    }
+
+    // Wrap methods to use queue, effectively solving all "Ledger Device is busy" errors.
+    _wrapper(fn) {
+      this.busy = true;
+      const queue = this.queue
+        .catch(()=>undefined)
+        .then(()=>fn())
+        .catch((err) => {
+          // console.log(`Hardwallet<${this.uid}> wrapper got error:`, err);
+          this.busy=false;
+          throw err;
+        })
+        .then((res)=>{
+          this.busy=false;
+          return res;
+        });
+      this.queue = queue;
+      return queue;
+    }
+
+    selectSubaccount(...args)   { return this._wrapper(()=>this._selectSubaccount(...args)   ); }
+    deselectSubaccount(...args) { return this._wrapper(()=>this._deselectSubaccount(...args) ); }
+    getAppConfig(...args)       { return this._wrapper(()=>this._getAppConfig(...args)       ); }
+    getPublicKey(...args)       { return this._wrapper(()=>this._getPublicKey(...args)       ); }
+    signTe(...args)             { return this._wrapper(()=>this._signTe(...args)             ); }
+    signHash(...args)           { return this._wrapper(()=>this._signHash(...args)           ); }
+    ping(...args)               { return this._wrapper(()=>this._ping(...args)               ); }
+
+  }
+
+
+  // Public static properties.
+  HardwareWalletLedger.listOfLedgers = new Map();
+  HardwareWalletLedger.listeners = [];
+
+
+  // Public static methods.
+  HardwareWalletLedger.isSupported = async () => {
+    return Transport.isSupported();
+  }
+
+  HardwareWalletLedger.list = () => {
+    return [...HardwareWalletLedger.listOfLedgers.values()].map((hww)=>({
+        device: hww.device,
+        publicKey: hww.publicKey,
+        state: hww.state,
+        subaccount: hww.subaccount,
+        uid: hww.uid,
+      }));
+  }
+
+  HardwareWalletLedger.init = () => {
+    HardwareWalletLedger.unsubscribeTransport = Transport.listen({next: async (e) => {
+      const uid = hash(JSON.stringify({
+        manufacturer: e.manufacturer,
+        product     : e.product     ,
+        productId   : e.productId   ,
+        release     : e.release     ,
+        serialNumber: e.serialNumber,
+        vendorId    : e.vendorId    ,
+      })).toString('base64').substr(0, 8);
+      // console.log(uid, e)
+      try {
+        switch(e.type) {
+          case('add'): {
+            if(!HardwareWalletLedger.listOfLedgers.has(uid)) HardwareWalletLedger.listOfLedgers.set(uid, new HardwareWalletLedger(uid, e.device));
+            await HardwareWalletLedger.listOfLedgers.get(uid)._changeState(HWW_STATE.ONLINE, e.descriptor);
+            break;
+          }
+          case('remove'): {
+            await HardwareWalletLedger.listOfLedgers.get(uid)._changeState(HWW_STATE.OFFLINE);
+            break;
+          }
+          default: {
+            throw new Error(`Unrecognized Ledger event '${e.type}'`)
+          }
+        }
+      } catch(err) {
+          console.error(`Hardwallet<${this.uid}>: Internal error.`, err)
+      }
+    }});
+  }
+
+  HardwareWalletLedger.cleanup = async function() {
+    HardwareWalletLedger.unsubscribeTransport();
+    HardwareWalletLedger.unsubscribeTransport = undefined;
+    await Promise.all([...HardwareWalletLedger.listOfLedgers.values()].map((ledger)=>ledger.deconstructor()));
+  }
+
+
+  return {
+    Ledger: HardwareWalletLedger,
+  }
+
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,28 @@
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
 
+"@ledgerhq/hw-app-str@^4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq%2fhw-app-str/-/hw-app-str-4.15.0.tgz#95f0d676b9ac7a6f4e598662a4553ec60b339b60"
+  dependencies:
+    "@ledgerhq/hw-transport" "^4.15.0"
+    base32.js "^0.1.0"
+    sha.js "^2.3.6"
+    tweetnacl "^1.0.0"
+
+"@ledgerhq/hw-transport-node-hid@^4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq%2fhw-transport-node-hid/-/hw-transport-node-hid-4.15.0.tgz#d25b1839230509235782884a5be3d56e791dad26"
+  dependencies:
+    "@ledgerhq/hw-transport" "^4.15.0"
+    node-hid "^0.7.2"
+
+"@ledgerhq/hw-transport@^4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq%2fhw-transport/-/hw-transport-4.15.0.tgz#ec99436c2662e70fb6f9c72f7bb5d1f3a051c4e3"
+  dependencies:
+    events "^2.0.0"
+
 "@types/node@^8.0.24":
   version "8.10.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
@@ -138,6 +160,17 @@ app-builder-bin@1.9.7:
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.9.7.tgz#9f01439fa8088a43471df9e5e071dd3880a8cff0"
 
+aproba@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+
+are-we-there-yet@~1.1.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -224,11 +257,18 @@ babel-runtime@^4.7.16:
   dependencies:
     core-js "^0.6.1"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base32.js@~0.1.0:
+base32.js@^0.1.0, base32.js@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base32.js/-/base32.js-0.1.0.tgz#b582dec693c2f11e893cf064ee6ac5b6131a2202"
 
@@ -257,9 +297,16 @@ binary@^0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
-bindings@^1.2.1:
+bindings@^1.2.1, bindings@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
+bl@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
 
 bluebird-lst@^1.0.5:
   version "1.0.5"
@@ -293,6 +340,21 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
+buffer-alloc@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0:
   version "1.1.0"
@@ -470,6 +532,10 @@ chartjs-color@^2.0.0, chartjs-color@^2.1.0:
     chartjs-color-string "^0.5.0"
     color-convert "^0.5.3"
 
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
 chromium-pickle-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205"
@@ -585,9 +651,17 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
 core-js@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-0.6.1.tgz#1b4970873e8101bf8c435af095faa9024f4b9b58"
+
+core-js@^2.4.0:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -659,6 +733,12 @@ decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
+
 decompress-zip@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/decompress-zip/-/decompress-zip-0.3.0.tgz#ae3bcb7e34c65879adfe77e19c30f86602b4bdb0"
@@ -694,6 +774,14 @@ del@^2.0.2:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 devtron@^1.4.0:
   version "1.4.0"
@@ -1017,6 +1105,12 @@ electron@2.0.2:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  dependencies:
+    once "^1.4.0"
+
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
@@ -1134,6 +1228,10 @@ event-source-polyfill@0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-0.0.12.tgz#e539cd67fdef2760a16aa5262fa98134df52e3af"
 
+events@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
+
 eventsource@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.5.tgz#1f012c9df0bd8832fd6b1744fea00ccdd479f046"
@@ -1151,6 +1249,10 @@ execa@^0.7.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+expand-template@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd"
 
 extend@~3.0.1:
   version "3.0.1"
@@ -1267,6 +1369,10 @@ form-data@~2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+
 fs-extra-p@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.6.0.tgz#c7b7117f0dcf8a99c9b2ed589067c960abcf3ef9"
@@ -1341,6 +1447,19 @@ galactus@^0.2.1:
     flora-colossus "^1.0.0"
     fs-extra "^4.0.0"
 
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -1367,6 +1486,10 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
 
 glob@^6.0.4:
   version "6.0.4"
@@ -1460,6 +1583,10 @@ has-flag@^1.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
 highlight.js@^9.3.0:
   version "9.12.0"
@@ -1899,6 +2026,10 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
+
 "minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -1943,7 +2074,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.9:
+nan@^2.0.9, nan@^2.6.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -1951,12 +2082,30 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+node-abi@^2.2.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.1.tgz#7628c4d4ec4e9cd3764ceb3652f36b2e7f8d4923"
+  dependencies:
+    semver "^5.4.1"
+
+node-hid@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-0.7.2.tgz#15025cdea2e9756aca2de7266529996d40e52c56"
+  dependencies:
+    bindings "^1.3.0"
+    nan "^2.6.2"
+    prebuild-install "^2.2.2"
+
 nodeify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/nodeify/-/nodeify-1.0.1.tgz#64ab69a7bdbaf03ce107b4f0335c87c0b9e91b1d"
   dependencies:
     is-promise "~1.0.0"
     promise "~1.3.0"
+
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
 
 nopt@^3.0.1:
   version "3.0.6"
@@ -1985,6 +2134,15 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npmlog@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
 nugget@^2.0.0, nugget@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
@@ -2005,7 +2163,7 @@ oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2013,7 +2171,7 @@ object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -2041,6 +2199,10 @@ original@^1.0.0:
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.1.tgz#b0a53ff42ba997a8c9cd1fb5daaeb42b9d693190"
   dependencies:
     url-parse "~1.4.0"
+
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
 os-locale@^2.0.0:
   version "2.1.0"
@@ -2191,6 +2353,26 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
+prebuild-install@^2.2.2:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.3.tgz#9f65f242782d370296353710e9bc843490c19f69"
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^1.0.2"
+    github-from-package "0.0.0"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    node-abi "^2.2.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    os-homedir "^1.0.1"
+    pump "^2.0.1"
+    rc "^1.1.6"
+    simple-get "^2.7.0"
+    tar-fs "^1.13.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -2230,6 +2412,20 @@ promise@~1.3.0:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+pump@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -2321,7 +2517,7 @@ readable-stream@^1.1.8, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.2, readable-stream@^2.2.2:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -2339,6 +2535,10 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regexpp@^1.0.1:
   version "1.1.0"
@@ -2482,7 +2682,7 @@ sequencify@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/sequencify/-/sequencify-0.0.7.tgz#90cff19d02e07027fd767f5ead3e7b95d1e7380c"
 
-set-blocking@^2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
@@ -2506,6 +2706,18 @@ shebang-regex@^1.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
+
+simple-get@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
+  dependencies:
+    decompress-response "^3.3.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 single-line-log@^1.1.2:
   version "1.1.2"
@@ -2629,7 +2841,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -2732,6 +2944,27 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
+tar-fs@^1.13.0:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.2.tgz#17e5239747e399f7e77344f5f53365f04af53577"
+  dependencies:
+    chownr "^1.0.1"
+    mkdirp "^0.5.1"
+    pump "^1.0.0"
+    tar-stream "^1.1.2"
+
+tar-stream@^1.1.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395"
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.1.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.0"
+    xtend "^4.0.0"
+
 temp-file@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-3.1.2.tgz#54ba4084097558e8ff2ad1e4bd84841ef2804043"
@@ -2781,6 +3014,10 @@ tmp@^0.0.33:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:
     os-tmpdir "~1.0.2"
+
+to-buffer@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
 
 toml@^2.3.0:
   version "2.3.3"
@@ -2927,11 +3164,21 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
+
+wide-align@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  dependencies:
+    string-width "^1.0.2 || 2"
 
 widest-line@^2.0.0:
   version "2.0.0"
@@ -2983,6 +3230,10 @@ xmlbuilder@^9.0.7:
 xmldom@0.1.x:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+
+xtend@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 xtend@~2.1.1:
   version "2.1.2"


### PR DESCRIPTION
HardwareWalletLedger provides high-level API for Ledger device with Stellar app.

As it turns out Ledger behavior is "pretty random" that depends on timing of interactions and computer's OS. Furthermore it lacks full introspection about which state it is in and whenever it's available for signing. This class creates wrapper with less random behavior and provide more information of the current state.

Class listens for added or removed Ledgers and manages a list of instances for each unique Ledger device. It also informs instances whenever its Ledger has gone offline or came back online. From there, each instance monitors itself via watchdog that tries to get public key and figures out current state based on success or error messages.

High-level wrapper provide the following benefits:
- more granular states (as discussed above)
- less inconsistent behavior across Linux and MacOS (it still has minor problems, and Windows is untested)
- request queue to solve "Ledger is busy" errors
- "selected subaccount" to mimic "login workflow" and so methods wont need it as explicit parameter

***

Along the way, set frame and minimal size of Electron app.

***

Ledger support took a while due trial-and-error exploration of above mentioned problems. For readability I will split the code into two PRs. This PR contains back-end code only, and next PR later will contain front-end part.

***

Created IPC calls for HardwareWalletLedger static and instance methods. You can test the functionality of very optimistic workflow from console like this:

```js
// Borrow helper from root scope.
invokeIPC = async (channel, ...args) => {
    const _id = Math.floor(Math.random()*10000);
    const promise = new Promise((resolve, reject)=>{
        const cb = (event, id, err, result) => {
            if(id!==_id) return;
            ipcRenderer.removeListener(channel, cb);
            if(err) { reject(err) } else { resolve(result) }
        }
        ipcRenderer.on(channel, cb)
    })
    ipcRenderer.send(channel, _id, ...args)
    return promise;
}

// Listen to all state changes of all connected Ledgers.
ipcRenderer.on(CONST.HWW_API.LISTEN, (event, uid, currState, prevState) => console.log(`${uid}: ${prevState} -> ${currState}`))

// Ask whenever your PC supports Ledger.
invokeIPC(CONST.HWW_API.SUPPORT).then((yesno)=>console.log(yesno))

// Lists all Ledgers seen so far. I.e. your Ledger's ID is 'RBNvo1Wz'.
invokeIPC(CONST.HWW_API.LIST).then((arrayOfDevices)=>console.log(arrayOfDevices))

// Get selected Public Key. Should return undefined, see below.
invokeIPC(CONST.HWW_API.PK, 'RBNvo1Wz').then((pk)=>console.log(pk))

// Get specific Public Key (no confirmation)
invokeIPC(CONST.HWW_API.PK, 'RBNvo1Wz', 1).then((pk)=>console.log(pk))

// Get list of specific Public Keys (no confirmation)
invokeIPC(CONST.HWW_API.PK, 'RBNvo1Wz', [1,2,3]).then((pks)=>console.log(pks))

// Select active Public Key used for signing (user has to confirm the public key)
invokeIPC(CONST.HWW_API.SELECT, 'RBNvo1Wz', 1).then((pk)=>console.log(pk))

// Get selected Public Key, again. Returns the same Public Key what you selected.
invokeIPC(CONST.HWW_API.PK, 'RBNvo1Wz').then((pk)=>console.log(pk))

// Sign transaction with selected Public Key. Returns base64 of XDR of signature.
invokeIPC(CONST.HWW_API.SIGN_TE, 'RBNvo1Wz', (new StellarSdk.Transaction(myTeXDR)).signatureBase().toString('base64')).then((sigXDR)=>console.log(sigXDR))
```