### PR TITLE
Add Copy&Paste capability on MacOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,33 @@
   const {HWW_API} = require('./src/common/constants')
   const HardwareWalletLedger = HardwareWallet.Ledger;
 
+  // Copy & Paste fix for MacOS
+  const defaultMenu = require('electron-default-menu')
+  const { Menu, shell } = electron
+  const dialog = require('electron').remote;
+
+  app.on('ready', () => {
+    // Get template for default menu
+    const menu = defaultMenu(app, shell)
+   
+    // Add custom menu
+    menu.splice(4, 0, {
+      label: 'Custom',
+      submenu: [
+        {
+          label: 'Do something',
+          click: (item, focusedWindow) => {
+            dialog.showMessageBox({message: 'Do something', buttons: ['OK'] })
+          }
+        }
+      ]
+    })
+   
+    // Set top-level application menu, using modified template
+    Menu.setApplicationMenu(Menu.buildFromTemplate(menu))
+  })
+
+
   // report crashes to the Electron project
   // require('crash-reporter').start()
   // adds debug features like hotkeys for triggering dev tools and reload

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "qrcode-generator": "^1.4.0",
     "sjcl": "^1.0.7",
     "stellar-sdk": "^0.8.2",
-    "underscore": "^1.9.1"
+    "underscore": "^1.9.1",
+    "electron-default-menu": "^1.0.1"
   },
   "devDependencies": {
     "concurrently": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
     "babel-runtime": "^6.26.0",
     "bootstrap": "^3.3.7",
     "chart.js": "^2.7.2",
+    "electron-default-menu": "^1.0.1",
     "electron-notifications": "^1.0.0",
     "font-awesome": "^4.7.0",
     "jquery": "^3.3.1",
     "qrcode-generator": "^1.4.0",
     "sjcl": "^1.0.7",
     "stellar-sdk": "^0.8.2",
-    "underscore": "^1.9.1",
-    "electron-default-menu": "^1.0.1"
+    "underscore": "^1.9.1"
   },
   "devDependencies": {
     "concurrently": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,6 +959,10 @@ electron-debug@^2.0.0:
     electron-is-dev "^0.3.0"
     electron-localshortcut "^3.0.0"
 
+electron-default-menu@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/electron-default-menu/-/electron-default-menu-1.0.1.tgz#3173c5018eb507404fec63bdf3b78c38eedba808"
+
 electron-devtools-installer@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz#261a50337e37121d338b966f07922eb4939a8763"


### PR DESCRIPTION
There's a problem with Electron on MacOS that it cannot copy (wallet ID) or paste once it's been built. So I have added a copy&paste capability to it.