### PR TITLE
Use error name to detect if account is funded

### DIFF
--- a/src/js/factory/stellar.js
+++ b/src/js/factory/stellar.js
@@ -49,7 +49,7 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
           await _server.accounts().accountId(address).call()
           return true;
         } catch(err) {
-          if (err.name == 'NotFoundError') return false;
+          if (err.name === 'NotFoundError' || err.message === 'Request failed with status code 404') return false;
           throw err
         }
       },

--- a/src/js/factory/stellar.js
+++ b/src/js/factory/stellar.js
@@ -49,7 +49,7 @@ myApp.factory('StellarApi', ['$rootScope', 'StellarHistory', 'StellarOrderbook',
           await _server.accounts().accountId(address).call()
           return true;
         } catch(err) {
-          if (err.message === 'Request failed with status code 404') return false;
+          if (err.name == 'NotFoundError') return false;
           throw err
         }
       },


### PR DESCRIPTION
Use error name to detect NotFoundError instead of the error message when checking if account is funded. This is consistent with how this error is caught in other functions in the same file.